### PR TITLE
Add utility SLRU implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/dgraph-io/ristretto
+
+go 1.12
+
+require (
+	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef
+	github.com/stretchr/testify v1.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef h1:veQD95Isof8w9/WXiA+pa3tz3fJXkt5B7QaRBrM62gk=
+github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/slru/slru.go
+++ b/slru/slru.go
@@ -58,7 +58,7 @@ func (c *Cache) Get(key []byte) (value []byte, ok bool) {
 		return
 	}
 
-	// Just promote the entry there's room in the next segment.
+	// Just promote the entry if there's room in the next segment.
 	if c.protected.Len() < c.maxProtected {
 		c.probation.Remove(e)
 		ent.segment = protected

--- a/slru/slru.go
+++ b/slru/slru.go
@@ -1,0 +1,140 @@
+package slru
+
+import (
+	"container/list"
+)
+
+type segment int
+
+const (
+	probation segment = iota
+	protected
+)
+
+// Cache is a segmented LRU cache. It is not safe for concurrent access.
+type Cache struct {
+	items        map[string]*list.Element
+	probation    *list.List
+	protected    *list.List
+	maxProbation int
+	maxProtected int
+}
+
+type entry struct {
+	key     []byte
+	value   []byte
+	segment segment
+}
+
+// New creates a new SLRU cache.
+//
+// Segment capacities must be positive.
+func New(maxProbation int, maxProtected int) *Cache {
+	if maxProbation < 1 || maxProtected < 1 {
+		panic("slru: segment capacities must be positive")
+	}
+
+	return &Cache{
+		items:        make(map[string]*list.Element),
+		probation:    list.New(),
+		maxProbation: maxProbation,
+		protected:    list.New(),
+		maxProtected: maxProtected,
+	}
+}
+
+// Get looks up a key's value from the cache.
+func (c *Cache) Get(key []byte) (value []byte, ok bool) {
+	keyStr := string(key)
+	e, hit := c.items[keyStr]
+	if !hit {
+		return
+	}
+	ent := e.Value.(*entry)
+	value, ok = ent.value, true
+
+	if ent.segment == protected {
+		c.protected.MoveToFront(e)
+		return
+	}
+
+	// Just promote the entry there's room in the next segment.
+	if c.protected.Len() < c.maxProtected {
+		c.probation.Remove(e)
+		ent.segment = protected
+		c.items[keyStr] = c.protected.PushFront(ent)
+		return
+	}
+
+	// Swap the entry with the oldest protected one in-place to minimize allocations.
+
+	prot := c.protected.Back()
+	victim := prot.Value.(*entry)
+	victim.segment = probation
+	ent.segment = protected
+	prot.Value, e.Value = e.Value, prot.Value
+
+	c.protected.MoveToFront(prot)
+	c.probation.MoveToFront(e)
+	c.items[keyStr] = prot
+	c.items[string(victim.key)] = e
+	return
+}
+
+// Set adds a value to the cache.
+func (c *Cache) Set(key []byte, value []byte) {
+	keyStr := string(key)
+	if _, ok := c.items[keyStr]; ok {
+		panic("slru: replacement of existing keys is not supported")
+	}
+
+	newItem := entry{key: key, value: value}
+
+	if c.probation.Len() < c.maxProbation || c.Len() < c.maxProbation+c.maxProtected {
+		c.items[keyStr] = c.probation.PushFront(&newItem)
+		return
+	}
+
+	// Reuse the tail item.
+	e := c.probation.Back()
+	item := e.Value.(*entry)
+
+	delete(c.items, string(item.key))
+
+	*item = newItem
+	c.items[keyStr] = e
+	c.probation.MoveToFront(e)
+}
+
+// Oldest looks up the next value to be removed from the cache. If the cache is
+// not at capacity, no value is returned.
+//
+// This is not counted as an access and therefore does not update recency.
+func (c *Cache) Oldest() (value []byte, ok bool) {
+	if c.Len() < c.maxProbation+c.maxProtected {
+		return
+	}
+	return c.probation.Back().Value.(*entry).value, true
+}
+
+// Len returns the number of items in the cache.
+func (c *Cache) Len() int {
+	return c.probation.Len() + c.protected.Len()
+}
+
+// Remove removes the provided key from the cache.
+func (c *Cache) Remove(key []byte) {
+	keyStr := string(key)
+	e, ok := c.items[keyStr]
+	if !ok {
+		return
+	}
+
+	if e.Value.(*entry).segment == protected {
+		c.protected.Remove(e)
+	} else {
+		c.probation.Remove(e)
+	}
+
+	delete(c.items, keyStr)
+}

--- a/slru/slru.go
+++ b/slru/slru.go
@@ -81,8 +81,8 @@ func (c *Cache) Get(key []byte) (value []byte, ok bool) {
 	return
 }
 
-// Set adds a value to the cache.
-func (c *Cache) Set(key []byte, value []byte) {
+// Add adds a value to the cache.
+func (c *Cache) Add(key []byte, value []byte) {
 	keyStr := string(key)
 	if _, ok := c.items[keyStr]; ok {
 		panic("slru: replacement of existing keys is not supported")

--- a/slru/slru_test.go
+++ b/slru/slru_test.go
@@ -1,0 +1,98 @@
+package slru
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGet(t *testing.T) {
+	key1, val1 := []byte{1}, []byte("one")
+	key2, val2 := []byte{2}, []byte("two")
+
+	c := New(1, 1)
+	c.Set(key1, val1)
+	c.Set(key2, val2)
+
+	v, ok := c.Get([]byte("missing"))
+	assert.Nil(t, v, "Get nonexistent")
+	assert.False(t, ok)
+
+	v, ok = c.Get(key1)
+	assert.Equal(t, val1, v, "Get first during probation")
+	assert.True(t, ok)
+
+	v, ok = c.Get(key1)
+	assert.Equal(t, val1, v, "Get first after promotion")
+	assert.True(t, ok)
+
+	v, ok = c.Get(key2)
+	assert.Equal(t, val2, v, "Get second during probation")
+	assert.True(t, ok)
+
+	v, ok = c.Get(key1)
+	assert.Equal(t, val1, v, "Get first after demotion")
+	assert.True(t, ok)
+}
+
+func TestRemove(t *testing.T) {
+	key1, val1 := []byte{1}, []byte("one")
+	key2, val2 := []byte{2}, []byte("two")
+
+	c := New(1, 1)
+	c.Set(key1, val1)
+	c.Set(key2, val2)
+	c.Get(key1) // Promote the first key.
+
+	c.Remove([]byte("missing")) // Test negatives.
+
+	c.Remove(key1)
+	_, ok := c.Get(key1)
+	assert.False(t, ok, "Remove from protected segment")
+
+	c.Remove(key2)
+	_, ok = c.Get(key2)
+	assert.False(t, ok, "Remove from probation segment")
+}
+
+func TestEviction(t *testing.T) {
+
+	tests := []struct {
+		Name          string
+		Gets          []int
+		ExpectedEvict int
+	}{
+		{"all_probational", nil, 0},
+		{"half_promoted", []int{0, 1}, 2},
+		{"each_accessed_once", []int{0, 1, 2, 3}, 0},
+		{"each_accessed_reverse", []int{3, 2, 1, 0}, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			c := New(2, 2)
+
+			var keys [][]byte
+			for i := byte(0); i < 4; i++ {
+				keys = append(keys, []byte{'k', 'e', 'y', i})
+				c.Set(keys[i], []byte{i})
+			}
+
+			for _, keyIndex := range tt.Gets {
+				c.Get(keys[keyIndex])
+			}
+
+			c.Set([]byte("new"), []byte("value"))
+
+			for i, key := range keys {
+				val, ok := c.Get(key)
+				if i == tt.ExpectedEvict {
+					assert.False(t, ok)
+				} else {
+					assert.True(t, ok)
+					assert.Equal(t, val, []byte{byte(i)})
+				}
+			}
+		})
+	}
+}

--- a/slru/slru_test.go
+++ b/slru/slru_test.go
@@ -11,8 +11,8 @@ func TestGet(t *testing.T) {
 	key2, val2 := []byte{2}, []byte("two")
 
 	c := New(1, 1)
-	c.Set(key1, val1)
-	c.Set(key2, val2)
+	c.Add(key1, val1)
+	c.Add(key2, val2)
 
 	v, ok := c.Get([]byte("missing"))
 	assert.Nil(t, v, "Get nonexistent")
@@ -40,8 +40,8 @@ func TestRemove(t *testing.T) {
 	key2, val2 := []byte{2}, []byte("two")
 
 	c := New(1, 1)
-	c.Set(key1, val1)
-	c.Set(key2, val2)
+	c.Add(key1, val1)
+	c.Add(key2, val2)
 	c.Get(key1) // Promote the first key.
 
 	c.Remove([]byte("missing")) // Test negatives.
@@ -75,14 +75,14 @@ func TestEviction(t *testing.T) {
 			var keys [][]byte
 			for i := byte(0); i < 4; i++ {
 				keys = append(keys, []byte{'k', 'e', 'y', i})
-				c.Set(keys[i], []byte{i})
+				c.Add(keys[i], []byte{i})
 			}
 
 			for _, keyIndex := range tt.Gets {
 				c.Get(keys[keyIndex])
 			}
 
-			c.Set([]byte("new"), []byte("value"))
+			c.Add([]byte("new"), []byte("value"))
 
 			for i, key := range keys {
 				val, ok := c.Get(key)


### PR DESCRIPTION
This adds a basic SLRU implementation meant to roughly match the example set by [github.com/golang/groupcache/lru](https://github.com/golang/groupcache/tree/master/lru).

Design choices:
- I dropped the lazy initialization pattern to skip unnecessary checks each function call.
- I added an Oldest accessor which will be needed for TinyLFU.
- Though I don't strictly adhere to the Cache interface, I did stick with the byte slice keys and values.
- There are likely a few unnecessary string conversions. I expect the map to be replaced, so they should be temporary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/16)
<!-- Reviewable:end -->
