### PR TITLE
Port TinyLFU eviction policy from Caffeine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/dgraph-io/ristretto
+
+go 1.12
+
+require (
+	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef
+	github.com/stretchr/testify v1.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef h1:veQD95Isof8w9/WXiA+pa3tz3fJXkt5B7QaRBrM62gk=
+github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/tinylfu/list.go
+++ b/tinylfu/list.go
@@ -1,0 +1,129 @@
+package tinylfu
+
+// list implements a doubly linked list. It is based on Go's built-in list.List,
+// but simplified for TinyLFU to reduce size per element and to remove the need
+// for allocations when moving elements between lists. Unlike the built-in list,
+// this struct must be initialized prior to use.
+type list struct {
+	// To simplify the implementation, internally a list l is implemented as a
+	// ring, such that root is both the next element of the l.Back() and the
+	// previous element of l.Front()
+	root element
+
+	// Current list length excluding the root.
+	len int
+}
+
+// newList returns an initialized list.
+func newList() *list { return new(list).Init() }
+
+// Init initializes or clears the list.
+func (l *list) Init() *list {
+	l.root.next = &l.root
+	l.root.prev = &l.root
+	l.len = 0
+	return l
+}
+
+// Len returns the number of elements in the list.
+func (l *list) Len() int { return l.len }
+
+// Front returns the first element of the list or nil if the list is empty.
+func (l *list) Front() *element {
+	if l.len == 0 {
+		return nil
+	}
+	return l.root.next
+}
+
+// Back returns the last element of the list or nil if the list is empty.
+func (l *list) Back() *element {
+	if l.len == 0 {
+		return nil
+	}
+	return l.root.prev
+}
+
+// PushFront inserts an element into a list.
+func (l *list) PushFront(e *element) {
+	if e.list != nil {
+		e.Remove()
+	}
+	e.next = l.root.next
+	e.prev = &l.root
+	l.root.next = e
+	e.next.prev = e
+	e.list = l
+	l.len++
+}
+
+func (l *list) PushBack(e *element) {
+	if e.list != nil {
+		e.Remove()
+	}
+	e.prev = l.root.prev
+	e.next = &l.root
+	l.root.prev = e
+	e.prev.next = e
+	e.list = l
+	l.len++
+}
+
+// element is a node within a linked list.
+type element struct {
+	next, prev *element
+	list       *list
+
+	Value uint64
+}
+
+// Next returns the next list element or nil.
+func (e *element) Next() *element {
+	if p := e.next; e.list != nil && p != &e.list.root {
+		return p
+	}
+	return nil
+}
+
+// Prev returns the previous list element or nil.
+func (e *element) Prev() *element {
+	if p := e.prev; e.list != nil && p != &e.list.root {
+		return p
+	}
+	return nil
+}
+
+// List returns the list containing the element or nil.
+func (e *element) List() *list {
+	return e.list
+}
+
+// Remove removes an element from its list.
+func (e *element) Remove() {
+	if e.list == nil {
+		return
+	}
+
+	e.list.len--
+	e.prev.next = e.next
+	e.next.prev = e.prev
+	e.next = nil
+	e.prev = nil
+	e.list = nil
+}
+
+// MoveToFront moves an element to the front of its list. The element must be
+// initialized and inserted into a list.
+func (e *element) MoveToFront() {
+	root := &e.list.root
+	if root.next == e {
+		return
+	}
+
+	e.prev.next = e.next
+	e.next.prev = e.prev
+	e.prev = root
+	e.next = root.next
+	root.next.prev = e
+	root.next = e
+}

--- a/tinylfu/list.go
+++ b/tinylfu/list.go
@@ -7,7 +7,8 @@ package tinylfu
 type list struct {
 	// To simplify the implementation, internally a list l is implemented as a
 	// ring, such that root is both the next element of the l.Back() and the
-	// previous element of l.Front()
+	// previous element of l.Front(). This sentinel is neither included in the
+	// list count nor enumerable via e.Next() and e.Back().
 	root element
 
 	// Current list length excluding the root.

--- a/tinylfu/list_test.go
+++ b/tinylfu/list_test.go
@@ -1,0 +1,180 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tinylfu
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPushFront(t *testing.T) {
+	t.Run("PushFront", func(t *testing.T) {
+		l := newList()
+		assert.Nil(t, l.Front())
+
+		var elements []*element
+		for i := 0; i < 3; i++ {
+			e := &element{Value: uint64(i)}
+			elements = append([]*element{e}, elements...)
+			l.PushFront(e)
+
+			assert.Equal(t, e, l.Front())
+			checkList(t, l, elements)
+		}
+	})
+
+	t.Run("ChangeLists", func(t *testing.T) {
+		l1, l2 := newList(), newList()
+		e := &element{Value: 42}
+		l1.PushFront(e)
+		l2.PushFront(e)
+		checkList(t, l1, nil)
+		checkList(t, l2, []*element{e})
+	})
+}
+
+func TestPushBack(t *testing.T) {
+	t.Run("PushFront", func(t *testing.T) {
+		l := newList()
+		assert.Nil(t, l.Back())
+
+		var elements []*element
+		for i := 0; i < 3; i++ {
+			e := &element{Value: uint64(i)}
+			elements = append(elements, e)
+			l.PushBack(e)
+
+			assert.Equal(t, e, l.Back())
+			checkList(t, l, elements)
+		}
+	})
+
+	t.Run("ChangeLists", func(t *testing.T) {
+		l1, l2 := newList(), newList()
+		e := &element{Value: 42}
+		l1.PushBack(e)
+		l2.PushBack(e)
+		checkList(t, l1, nil)
+		checkList(t, l2, []*element{e})
+	})
+}
+
+func TestRemove(t *testing.T) {
+	t.Run("Uninitialized", func(t *testing.T) {
+		e := &element{}
+		assert.NotPanics(t, func() { e.Remove() })
+	})
+
+	t.Run("SingleElement", func(t *testing.T) {
+		e := &element{}
+		l := newList()
+		l.PushFront(e)
+		checkList(t, l, []*element{e})
+		e.Remove()
+		checkList(t, l, nil)
+	})
+
+	// Test removal of the head, middle, and tail.
+	for i := 0; i < 3; i++ {
+		l := newList()
+		var elements []*element
+		var remove *element
+
+		for ei := 0; ei < 3; ei++ {
+			e := &element{Value: uint64(ei)}
+			l.PushBack(e)
+			if ei == i {
+				remove = e
+			} else {
+				elements = append(elements, e)
+			}
+		}
+
+		t.Run(fmt.Sprintf("Remove%dOf3", i), func(t *testing.T) {
+			remove.Remove()
+			assert.Nil(t, remove.prev)
+			assert.Nil(t, remove.next)
+			assert.Nil(t, remove.list)
+			checkList(t, l, elements)
+		})
+	}
+}
+
+func TestMoveToFront(t *testing.T) {
+	t.Run("Uninitialized", func(t *testing.T) {
+		e := &element{}
+		assert.Panics(t, func() { e.MoveToFront() })
+	})
+
+	t.Run("SingleElement", func(t *testing.T) {
+		e := &element{}
+		l := newList()
+		l.PushFront(e)
+		e.MoveToFront()
+		checkList(t, l, []*element{e})
+	})
+
+	// Test removal of the head, middle, and tail.
+	for i := 0; i < 3; i++ {
+		l := newList()
+		var elements []*element
+		var move *element
+
+		for ei := 0; ei < 3; ei++ {
+			e := &element{Value: uint64(ei)}
+			l.PushBack(e)
+			if ei == i {
+				move = e
+				elements = append([]*element{e}, elements...)
+			} else {
+				elements = append(elements, e)
+			}
+		}
+
+		t.Run(fmt.Sprintf("Move%dOf3", i), func(t *testing.T) {
+			move.MoveToFront()
+			checkList(t, l, elements)
+		})
+	}
+}
+
+func checkList(t *testing.T, l *list, elements []*element) {
+	t.Helper()
+
+	root := &l.root
+	if !assert.Equal(t, len(elements), l.Len(), "list length") {
+		return
+	}
+
+	// Special case: empty list
+	if len(elements) == 0 {
+		if root.next != nil && root.next != root || root.prev != nil && root.prev != root {
+			t.Errorf("l.root.next = %p, l.root.prev = %p; both should both be nil or %p", l.root.next, l.root.prev, root)
+		}
+		return
+	}
+
+	for i, e := range elements {
+		assert.Equal(t, l, e.List())
+
+		if i > 0 {
+			assert.Equal(t, elements[i-1], e.prev, "internal prev pointer")
+			assert.Equal(t, elements[i-1], e.Prev(), "external prev pointer")
+		} else {
+			assert.Equal(t, root, e.prev, "internal prev pointer")
+			assert.Nil(t, e.Prev(), "external prev pointer")
+		}
+
+		if i < len(elements)-1 {
+			assert.Equal(t, elements[i+1], e.next, "internal next pointer")
+			assert.Equal(t, elements[i+1], e.Next(), "external next pointer")
+		} else {
+			assert.Equal(t, root, e.next, "internal next pointer")
+			assert.Nil(t, e.Next(), "external next pointer")
+		}
+	}
+}

--- a/tinylfu/list_test.go
+++ b/tinylfu/list_test.go
@@ -38,7 +38,7 @@ func TestPushFront(t *testing.T) {
 }
 
 func TestPushBack(t *testing.T) {
-	t.Run("PushFront", func(t *testing.T) {
+	t.Run("PushBack", func(t *testing.T) {
 		l := newList()
 		assert.Nil(t, l.Back())
 
@@ -94,7 +94,7 @@ func TestRemove(t *testing.T) {
 			}
 		}
 
-		t.Run(fmt.Sprintf("Remove%dOf3", i), func(t *testing.T) {
+		t.Run(fmt.Sprintf("Remove_%d_of_3", i), func(t *testing.T) {
 			remove.Remove()
 			assert.Nil(t, remove.prev)
 			assert.Nil(t, remove.next)

--- a/tinylfu/option.go
+++ b/tinylfu/option.go
@@ -1,0 +1,76 @@
+package tinylfu
+
+// A Option allows callers to configure a Cache.
+type Option func(p *Policy)
+
+// An AdmissionPolicy augments a cache's eviction policy by letting the cache
+// drop a new entry in favor of a victim which is more likely to be used again.
+type AdmissionPolicy interface {
+	Record(key uint64)
+	Admit(candidate uint64, victim uint64) bool
+}
+
+// WithAdmission configures TinyLFU's admission policy, i.e. whether it rejects
+// new entries in favor of evicting existing entries.
+//
+// By default, TinyLFU assumes admission.
+func WithAdmission(admittor AdmissionPolicy) Option {
+	return func(p *Policy) {
+		p.admittor = admittor
+	}
+}
+
+// A StatsRecorder allows TinyLFU to report performance metrics.
+type StatsRecorder interface {
+	RecordMiss()
+	RecordHit()
+	RecordEviction()
+}
+
+// WithRecorder configures TinyLFU to use the given instrumentation.
+func WithRecorder(recorder StatsRecorder) Option {
+	return func(p *Policy) {
+		p.stats = recorder
+	}
+}
+
+// WithSegmentation configures the relative sizes of TinyLFU's cache segments.
+//
+// TinyLFU uses two primary caches: an admission window to reduce the impact of
+// many one-off accesses and a main cache. The main cache is further split into
+// a probation segment and a protected segment for hot (frequent) entries.
+//
+// While optimal values may vary widely by workload, the default main and
+// protected segments of 0.99 and 0.80, respectively, are good starting values.
+//
+// Example: Given a total capacity = 1000 with default segmentation
+//   Window    = 1000 * (1 - 0.99)   = 10
+//   Protected = 1000 * (0.99 * 0.8) = 792
+//   Probation = 1000 - 792 - 10     = 198
+func WithSegmentation(main, protected float64) Option {
+	if main < 0 || main > 1 || protected < 0 || protected > 1 {
+		panic("tinylfu: cache segment ratios must be within the range [0, 1]")
+	}
+
+	return func(p *Policy) {
+		maxMain := int(float64(p.capacity) * main)
+		if maxMain < 2 {
+			// Leave at least one capacity each for probation and protected.
+			maxMain = 2
+		}
+		if maxMain == p.capacity {
+			// Leave at least one element for the window.
+			maxMain = p.capacity - 1
+		}
+		p.maxWindow = p.capacity - maxMain
+
+		p.maxProtected = int(float64(maxMain) * protected)
+		if p.maxProtected < 1 {
+			p.maxProtected = 1
+		}
+		if p.maxProtected == maxMain {
+			// Leave at least one element for probation.
+			p.maxProtected = maxMain - 1
+		}
+	}
+}

--- a/tinylfu/option.go
+++ b/tinylfu/option.go
@@ -15,6 +15,10 @@ type AdmissionPolicy interface {
 //
 // By default, TinyLFU assumes admission.
 func WithAdmission(admittor AdmissionPolicy) Option {
+	if admittor == nil {
+		panic("tinylfu: admission policy must be non-nil")
+	}
+
 	return func(p *Policy) {
 		p.admittor = admittor
 	}
@@ -29,6 +33,10 @@ type StatsRecorder interface {
 
 // WithRecorder configures TinyLFU to use the given instrumentation.
 func WithRecorder(recorder StatsRecorder) Option {
+	if recorder == nil {
+		panic("tinylfu: stats recorder must be non-nil")
+	}
+
 	return func(p *Policy) {
 		p.stats = recorder
 	}

--- a/tinylfu/option_test.go
+++ b/tinylfu/option_test.go
@@ -1,0 +1,40 @@
+package tinylfu
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithSegmentation(t *testing.T) {
+	// Minimal
+	p := New(3)
+	assert.Equal(t, 3, p.capacity)
+	assert.Equal(t, 1, p.maxWindow)
+	assert.Equal(t, 1, p.maxProtected)
+
+	// Defaults
+	p = New(1000)
+	assert.Equal(t, 10, p.maxWindow)
+	assert.Equal(t, 792, p.maxProtected)
+
+	// Non-default
+	p = New(50, WithSegmentation(.8, .5))
+	assert.Equal(t, 10, p.maxWindow)
+	assert.Equal(t, 20, p.maxProtected)
+
+	// Maximum window
+	p = New(1000, WithSegmentation(0, 0))
+	assert.Equal(t, 998, p.maxWindow)
+	assert.Equal(t, 1, p.maxProtected)
+
+	// Maximum probation
+	p = New(1000, WithSegmentation(1, 0))
+	assert.Equal(t, 1, p.maxWindow)
+	assert.Equal(t, 1, p.maxProtected)
+
+	// Maximum protected
+	p = New(1000, WithSegmentation(1, 1))
+	assert.Equal(t, 1, p.maxWindow)
+	assert.Equal(t, 998, p.maxProtected)
+}

--- a/tinylfu/tinylfu.go
+++ b/tinylfu/tinylfu.go
@@ -1,0 +1,122 @@
+// Package tinylfu is an implementation of the W-TinyLFU caching algorithm.
+// See details at http://arxiv.org/abs/1512.00727
+package tinylfu
+
+// Policy implements a windowed TinyLFU eviction policy. It is not safe for concurrent access.
+type Policy struct {
+	data     map[uint64]*element
+	admittor AdmissionPolicy
+	stats    StatsRecorder
+
+	window    *list
+	probation *list
+	protected *list
+
+	capacity     int
+	maxWindow    int
+	maxProtected int
+}
+
+// New creates a new TinyLFU cache.
+func New(capacity int, opts ...Option) *Policy {
+	// Consistent behavior relies on capacity for one element in each segment.
+	if capacity < 3 {
+		panic("tinylfu: capacity must be positive")
+	}
+
+	p := &Policy{
+		data:      make(map[uint64]*element),
+		window:    newList(),
+		probation: newList(),
+		protected: newList(),
+		capacity:  capacity,
+	}
+
+	WithSegmentation(0.99, 0.8)(p)
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// Len returns the number of items in the cache.
+func (p *Policy) Len() int {
+	return p.window.Len() + p.probation.Len() + p.protected.Len()
+}
+
+// Record updates the policy when an entry is accessed.
+func (p *Policy) Record(key uint64) {
+	if p.admittor != nil {
+		p.admittor.Record(key)
+	}
+
+	node, ok := p.data[key]
+	if !ok {
+		if p.stats != nil {
+			p.stats.RecordMiss()
+		}
+		p.onMiss(key)
+		return
+	}
+
+	switch node.List() {
+	case p.window, p.protected:
+		if p.stats != nil {
+			p.stats.RecordHit()
+		}
+		node.MoveToFront()
+
+	case p.probation:
+		if p.stats != nil {
+			p.stats.RecordHit()
+		}
+
+		// Promote the accessed item to the protected segment.
+		p.protected.PushFront(node)
+
+		// Demote the oldest protected item if needed.
+		if p.protected.Len() > p.maxProtected {
+			p.probation.PushFront(p.protected.Back())
+		}
+	}
+}
+
+// onMiss adds the entry to the admission window, evicting if necessary.
+func (p *Policy) onMiss(key uint64) {
+	// This assumes maxWindow >= 1 or the following promotion panics.
+	if p.window.Len() < p.maxWindow {
+		p.insertNew(key)
+		return
+	}
+
+	candidate := p.window.Back()
+	p.probation.PushFront(candidate)
+
+	// This assumes capacity >= 2 or the following eviction panics.
+	if len(p.data) < p.capacity {
+		p.insertNew(key)
+		return
+	}
+
+	victim, evict := p.probation.Back(), candidate
+	if p.admittor == nil || p.admittor.Admit(candidate.Value, victim.Value) {
+		evict = victim
+	}
+
+	delete(p.data, evict.Value)
+	evict.Value = key
+	p.data[key] = evict
+	p.window.PushFront(evict)
+
+	if p.stats != nil {
+		p.stats.RecordEviction()
+	}
+}
+
+// insertNew allocates a new element and adds it to the admission window segment.
+// This is the only time a node is allocated.
+func (p *Policy) insertNew(key uint64) {
+	node := &element{Value: key}
+	p.window.PushFront(node)
+	p.data[key] = node
+}

--- a/tinylfu/tinylfu.go
+++ b/tinylfu/tinylfu.go
@@ -21,7 +21,7 @@ type Policy struct {
 func New(capacity int, opts ...Option) *Policy {
 	// Consistent behavior relies on capacity for one element in each segment.
 	if capacity < 3 {
-		panic("tinylfu: capacity must be positive")
+		panic("tinylfu: capacity must be at least 3 (1 for each segment)")
 	}
 
 	p := &Policy{

--- a/tinylfu/tinylfu_test.go
+++ b/tinylfu/tinylfu_test.go
@@ -56,7 +56,12 @@ func TestTinyLFU(t *testing.T) {
 	checkSegment(t, p.protected, []uint64{5, 2, 3, 1})
 
 	// Finally, promote a window value.
-	//f
+	p.Record(11)
+
+	checkData(t, p, []uint64{1, 2, 3, 5, 7, 10, 11, 12})
+	checkSegment(t, p.window, []uint64{11, 12})
+	checkSegment(t, p.probation, []uint64{10, 7})
+	checkSegment(t, p.protected, []uint64{5, 2, 3, 1})
 }
 
 func newTestPolicy(t *testing.T) *Policy {

--- a/tinylfu/tinylfu_test.go
+++ b/tinylfu/tinylfu_test.go
@@ -67,7 +67,7 @@ func TestTinyLFU(t *testing.T) {
 func newTestPolicy(t *testing.T) *Policy {
 	// Create a policy with 2 window, 2 probation, 4 protected slots. This is
 	// enough to fully exercise most cases without being onerous to validate
-	// comprehensivley.
+	// comprehensively.
 	return New(8, WithSegmentation(.75, .67))
 }
 

--- a/tinylfu/tinylfu_test.go
+++ b/tinylfu/tinylfu_test.go
@@ -1,0 +1,96 @@
+package tinylfu
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUniformSaturation(t *testing.T) {
+	p := newTestPolicy(t)
+	for i := 0; i < 20; i++ {
+		p.Record(uint64(i))
+	}
+
+	checkData(t, p, []uint64{12, 13, 14, 15, 16, 17, 18, 19})
+	checkSegment(t, p.window, []uint64{19, 18})
+	checkSegment(t, p.probation, []uint64{17, 16, 15, 14, 13, 12})
+	checkSegment(t, p.protected, nil)
+}
+
+func TestTinyLFU(t *testing.T) {
+	p := newTestPolicy(t)
+
+	// Saturate the window and probation segments.
+	for i := 0; i < 8; i++ {
+		p.Record(uint64(i))
+	}
+
+	// Access some probation, but don't evict or demote anything yet.
+	for i := 0; i < 4; i++ {
+		p.Record(uint64(i))
+	}
+
+	checkData(t, p, []uint64{0, 1, 2, 3, 4, 5, 6, 7})
+	checkSegment(t, p.window, []uint64{7, 6})
+	checkSegment(t, p.probation, []uint64{5, 4})
+	checkSegment(t, p.protected, []uint64{3, 2, 1, 0})
+
+	// Refresh something in the protected region and promote something from probation.
+	p.Record(2)
+	p.Record(5) // Demote 0
+
+	checkData(t, p, []uint64{0, 1, 2, 3, 4, 5, 6, 7})
+	checkSegment(t, p.window, []uint64{7, 6})
+	checkSegment(t, p.probation, []uint64{0, 4})
+	checkSegment(t, p.protected, []uint64{5, 2, 3, 1})
+
+	// Evict a few values.
+	for i := 10; i < 13; i++ {
+		p.Record(uint64(i))
+	}
+
+	checkData(t, p, []uint64{1, 2, 3, 5, 7, 10, 11, 12})
+	checkSegment(t, p.window, []uint64{12, 11})
+	checkSegment(t, p.probation, []uint64{10, 7})
+	checkSegment(t, p.protected, []uint64{5, 2, 3, 1})
+
+	// Finally, promote a window value.
+	//f
+}
+
+func newTestPolicy(t *testing.T) *Policy {
+	// Create a policy with 2 window, 2 probation, 4 protected slots. This is
+	// enough to fully exercise most cases without being onerous to validate
+	// comprehensivley.
+	return New(8, WithSegmentation(.75, .67))
+}
+
+// Verify a policy's data map contains the given keys in any order.
+func checkData(t *testing.T, p *Policy, values []uint64) {
+	t.Helper()
+	if !assert.Equal(t, len(values), len(p.data), "data size") {
+		return
+	}
+
+	for _, v := range values {
+		e, ok := p.data[v]
+		if assert.True(t, ok, "key %d exists", v) {
+			assert.Equal(t, v, e.Value, "entry node matches key")
+		}
+	}
+}
+
+// Verify a segment contains the given values in order.
+func checkSegment(t *testing.T, l *list, values []uint64) {
+	t.Helper()
+	if !assert.Equal(t, len(values), l.Len(), "segment size") {
+		return
+	}
+
+	node := l.Front()
+	for _, v := range values {
+		assert.Equal(t, v, node.Value)
+		node = node.Next()
+	}
+}


### PR DESCRIPTION
The implementation included in this change is non-concurrent. It allows
injection of admission policies, but provides none yet. Further, storage
of key/value is left as a separate exercise; this tracks only whether a
key should be cached or evicted. Some small improvements have been made
over Caffeine to reduce allocation of list nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/17)
<!-- Reviewable:end -->
