### PR TITLE
switch to uint64 keys internally

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -31,7 +31,7 @@ type Cache struct {
 	data   store
 	policy Policy
 	buffer *ringBuffer
-	notify func(string)
+	notify func(uint64)
 }
 
 type Config struct {
@@ -43,6 +43,9 @@ type Config struct {
 	MaxCost int64
 	// BufferItems is max number of items in access batches (BP-Wrapper).
 	BufferItems int64
+	// OnEvict is ran for each key evicted. We do not store key strings, so the
+	// param is the AESHash of the key.
+	OnEvict func(uint64)
 	// Log is whether or not to Log hit ratio statistics (with some overhead).
 	Log bool
 }
@@ -67,6 +70,7 @@ func NewCache(config *Config) *Cache {
 			Consumer: policy,
 			Capacity: config.BufferItems,
 		}),
+		notify: config.OnEvict,
 	}
 }
 
@@ -84,6 +88,9 @@ func (c *Cache) Set(key string, val interface{}, cost int64) bool {
 	}
 	for _, victim := range victims {
 		c.data.Del(victim)
+		if c.notify != nil {
+			c.notify(victim)
+		}
 	}
 	c.data.Set(hashed, val)
 	return true

--- a/cache.go
+++ b/cache.go
@@ -16,6 +16,8 @@
 
 package ristretto
 
+import "github.com/dgraph-io/ristretto/z"
+
 // Cache ties everything together. The three main components are:
 //
 //     1) The hash map: this is the Map interface.
@@ -41,8 +43,6 @@ type Config struct {
 	MaxCost int64
 	// BufferItems is max number of items in access batches (BP-Wrapper).
 	BufferItems int64
-	// OnEvict is ran for each key evicted.
-	OnEvict func(string)
 	// Log is whether or not to Log hit ratio statistics (with some overhead).
 	Log bool
 }
@@ -67,33 +67,32 @@ func NewCache(config *Config) *Cache {
 			Consumer: policy,
 			Capacity: config.BufferItems,
 		}),
-		notify: config.OnEvict,
 	}
 }
 
 func (c *Cache) Get(key string) interface{} {
-	c.buffer.Push(key)
-	return c.data.Get(key)
+	hashed := z.AESHashString(key)
+	c.buffer.Push(hashed)
+	return c.data.Get(hashed)
 }
 
-func (c *Cache) Set(key string, val interface{}, cost int64) ([]string, bool) {
-	victims, added := c.policy.Add(key, cost)
+func (c *Cache) Set(key string, val interface{}, cost int64) bool {
+	hashed := z.AESHashString(key)
+	victims, added := c.policy.Add(hashed, cost)
 	if !added {
-		return nil, false
+		return false
 	}
 	for _, victim := range victims {
 		c.data.Del(victim)
-		if c.notify != nil {
-			c.notify(victim)
-		}
 	}
-	c.data.Set(key, val)
-	return victims, true
+	c.data.Set(hashed, val)
+	return true
 }
 
 func (c *Cache) Del(key string) {
-	c.policy.Del(key)
-	c.data.Del(key)
+	hashed := z.AESHashString(key)
+	c.policy.Del(hashed)
+	c.data.Del(hashed)
 }
 
 func (c *Cache) Log() *PolicyLog {

--- a/cache_test.go
+++ b/cache_test.go
@@ -47,7 +47,6 @@ func newCache(config *Config, p PolicyCreator) *Cache {
 			Consumer: policy,
 			Capacity: config.BufferItems,
 		}),
-		notify: config.OnEvict,
 	}
 }
 
@@ -128,7 +127,7 @@ func TestCacheBasic(t *testing.T) {
 		NumCounters: 4,
 		BufferItems: 1,
 	})
-	if _, added := c.Set("1", 1, 1); !added {
+	if added := c.Set("1", 1, 1); !added {
 		t.Fatal("set error")
 	}
 	if value := c.Get("1"); value.(int) != 1 {
@@ -143,32 +142,12 @@ func TestCacheSetGet(t *testing.T) {
 	})
 	for i := 0; i < 16; i++ {
 		key := fmt.Sprintf("%d", i)
-		if victims, added := c.Set(key, i, 1); added {
-			if i > 4 && victims == nil {
-				t.Fatal("no eviction")
-			}
+		if added := c.Set(key, i, 1); added {
 			value := c.Get(key)
 			if value == nil || value.(int) != i {
 				t.Fatal("set/get error")
 			}
 		}
-	}
-}
-
-func TestCacheOnEvict(t *testing.T) {
-	v := make([]string, 0)
-	c := NewCache(&Config{
-		NumCounters: 4,
-		BufferItems: 1,
-		OnEvict: func(key string) {
-			v = append(v, key)
-		},
-	})
-	for i := 0; i < 16; i++ {
-		c.Set(fmt.Sprintf("%d", i), i, 1)
-	}
-	if len(v) != 12 {
-		t.Fatal("onevict callback error")
 	}
 }
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -135,6 +135,23 @@ func TestCacheBasic(t *testing.T) {
 	}
 }
 
+func TestCacheOnEvict(t *testing.T) {
+	v := make([]uint64, 0)
+	c := NewCache(&Config{
+		NumCounters: 4,
+		BufferItems: 1,
+		OnEvict: func(key uint64) {
+			v = append(v, key)
+		},
+	})
+	for i := 0; i < 16; i++ {
+		c.Set(fmt.Sprintf("%d", i), i, 1)
+	}
+	if len(v) != 12 {
+		t.Fatal("onevict callback error")
+	}
+}
+
 func TestCacheSetGet(t *testing.T) {
 	c := NewCache(&Config{
 		NumCounters: 4,

--- a/policy_test.go
+++ b/policy_test.go
@@ -17,7 +17,6 @@
 package ristretto
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -28,43 +27,43 @@ func GeneratePolicyTest(create PolicyCreator) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Run("uniform-push", func(t *testing.T) {
 			policy := create(iterations, iterations)
-			values := make([]string, iterations)
+			values := make([]uint64, iterations)
 			for i := range values {
-				values[i] = string(fmt.Sprintf("%d", i))
+				values[i] = uint64(i)
 			}
-			policy.Add("0", 1)
+			policy.Add(0, 1)
 			policy.Push(values)
-			if !policy.Has("0") || policy.Has("*") {
+			if !policy.Has(0) || policy.Has(999999) {
 				t.Fatal("add/push error")
 			}
 		})
 		t.Run("uniform-add", func(t *testing.T) {
 			policy := create(iterations, iterations)
 			for i := int64(0); i < iterations; i++ {
-				policy.Add(fmt.Sprintf("%d", i), 1)
+				policy.Add(uint64(i), 1)
 			}
-			if victims, added := policy.Add("*", 1); victims == nil || !added {
+			if victims, added := policy.Add(999999, 1); victims == nil || !added {
 				t.Fatal("add/eviction error")
 			}
 		})
 		t.Run("variable-push", func(t *testing.T) {
 			policy := create(iterations, iterations*4)
-			values := make([]string, iterations)
+			values := make([]uint64, iterations)
 			for i := range values {
-				values[i] = string(fmt.Sprintf("%d", i))
+				values[i] = uint64(i)
 			}
-			policy.Add("0", 1)
+			policy.Add(0, 1)
 			policy.Push(values)
-			if !policy.Has("0") || policy.Has("*") {
+			if !policy.Has(0) || policy.Has(999999) {
 				t.Fatal("add/push error")
 			}
 		})
 		t.Run("variable-add", func(t *testing.T) {
 			policy := create(iterations, iterations*4)
 			for i := int64(0); i < iterations; i++ {
-				policy.Add(fmt.Sprintf("%d", i), 4)
+				policy.Add(uint64(i), 4)
 			}
-			if victims, added := policy.Add("*", 1); victims == nil || !added {
+			if victims, added := policy.Add(999999, 1); victims == nil || !added {
 				t.Fatal("add/eviction error")
 			}
 		})

--- a/ring_test.go
+++ b/ring_test.go
@@ -29,28 +29,28 @@ const (
 
 type BaseConsumer struct{}
 
-func (c *BaseConsumer) Push(items []string) {}
+func (c *BaseConsumer) Push(items []uint64) {}
 
 type TestConsumer struct {
-	push func([]string)
+	push func([]uint64)
 }
 
-func (c *TestConsumer) Push(items []string) { c.push(items) }
+func (c *TestConsumer) Push(items []uint64) { c.push(items) }
 
 func TestRingLossy(t *testing.T) {
 	drainCount := 0
 	buffer := newRingBuffer(ringLossy, &ringConfig{
 		Consumer: &TestConsumer{
-			push: func(items []string) {
+			push: func(items []uint64) {
 				drainCount++
 			},
 		},
 		Capacity: 4,
 	})
-	buffer.Push(string("1"))
-	buffer.Push(string("2"))
-	buffer.Push(string("3"))
-	buffer.Push(string("4"))
+	buffer.Push(1)
+	buffer.Push(2)
+	buffer.Push(3)
+	buffer.Push(4)
 	if drainCount != 1 {
 		t.Fatal("drain error")
 	}
@@ -61,7 +61,7 @@ func BenchmarkRingLossy(b *testing.B) {
 		Consumer: &BaseConsumer{},
 		Capacity: RING_CAPACITY,
 	})
-	item := string("1")
+	item := uint64(1)
 	b.Run("single", func(b *testing.B) {
 		b.SetBytes(1)
 		for n := 0; n < b.N; n++ {
@@ -84,7 +84,7 @@ func BenchmarkRingLossless(b *testing.B) {
 		Stripes:  RING_STRIPES,
 		Capacity: RING_CAPACITY,
 	})
-	item := string("1")
+	item := uint64(1)
 	b.Run("single", func(b *testing.B) {
 		b.SetBytes(1)
 		for n := 0; n < b.N; n++ {

--- a/store.go
+++ b/store.go
@@ -26,12 +26,12 @@ import "sync"
 // Every store is safe for concurrent usage.
 type store interface {
 	// Get returns the value associated with the key parameter.
-	Get(string) interface{}
+	Get(uint64) interface{}
 	// Set adds the key-value pair to the Map or updates the value if it's
 	// already present.
-	Set(string, interface{})
+	Set(uint64, interface{})
 	// Del deletes the key-value pair from the Map.
-	Del(string)
+	Del(uint64)
 	// Run applies the function parameter to random key-value pairs. No key
 	// will be visited more than once. If the function returns false, the
 	// iteration stops. If the function returns true, the iteration will
@@ -52,16 +52,16 @@ func newSyncMap() store {
 	return &syncMap{&sync.Map{}}
 }
 
-func (m *syncMap) Get(key string) interface{} {
+func (m *syncMap) Get(key uint64) interface{} {
 	value, _ := m.Load(key)
 	return value
 }
 
-func (m *syncMap) Set(key string, value interface{}) {
+func (m *syncMap) Set(key uint64, value interface{}) {
 	m.Store(key, value)
 }
 
-func (m *syncMap) Del(key string) {
+func (m *syncMap) Del(key uint64) {
 	m.Delete(key)
 }
 
@@ -71,26 +71,26 @@ func (m *syncMap) Run(f func(key, value interface{}) bool) {
 
 type lockedMap struct {
 	sync.RWMutex
-	data map[string]interface{}
+	data map[uint64]interface{}
 }
 
 func newLockedMap() *lockedMap {
-	return &lockedMap{data: make(map[string]interface{})}
+	return &lockedMap{data: make(map[uint64]interface{})}
 }
 
-func (m *lockedMap) Get(key string) interface{} {
+func (m *lockedMap) Get(key uint64) interface{} {
 	m.RLock()
 	defer m.RUnlock()
 	return m.data[key]
 }
 
-func (m *lockedMap) Set(key string, value interface{}) {
+func (m *lockedMap) Set(key uint64, value interface{}) {
 	m.Lock()
 	defer m.Unlock()
 	m.data[key] = value
 }
 
-func (m *lockedMap) Del(key string) {
+func (m *lockedMap) Del(key uint64) {
 	m.Lock()
 	defer m.Unlock()
 	delete(m.data, key)

--- a/store_test.go
+++ b/store_test.go
@@ -17,7 +17,6 @@
 package ristretto
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -33,12 +32,12 @@ func GenerateBench(create func() store) func(*testing.B) {
 	return func(b *testing.B) {
 		b.Run("get  ", func(b *testing.B) {
 			m := create()
-			m.Set("*", 1)
+			m.Set(1, 1)
 			b.SetBytes(1)
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
-					m.Get("*")
+					m.Get(1)
 				}
 			})
 		})
@@ -61,26 +60,26 @@ func GenerateTest(create func() store) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Run("set/get", func(t *testing.T) {
 			m := create()
-			m.Set("*", 1)
-			if m.Get("*").(int) != 1 {
+			m.Set(1, 1)
+			if m.Get(1).(int) != 1 {
 				t.Fatal("set-get error")
 			}
 		})
 		t.Run("set", func(t *testing.T) {
 			m := create()
-			m.Set("*", 1)
+			m.Set(1, 1)
 			// overwrite
-			m.Set("*", 2)
-			if m.Get("*").(int) != 2 {
+			m.Set(1, 2)
+			if m.Get(1).(int) != 2 {
 				t.Fatal("set update error")
 			}
 		})
 		t.Run("del", func(t *testing.T) {
 			m := create()
-			m.Set("*", 1)
+			m.Set(1, 1)
 			// delete item
-			m.Del("*")
-			if m.Get("*") != nil {
+			m.Del(1)
+			if m.Get(1) != nil {
 				t.Fatal("del error")
 			}
 		})
@@ -89,13 +88,13 @@ func GenerateTest(create func() store) func(*testing.T) {
 			n := 10
 			// populate with incrementing ints
 			for i := 0; i < n; i++ {
-				m.Set(fmt.Sprintf("%d", i), i)
+				m.Set(uint64(i), i)
 			}
 			// will hold items collected during Run
-			check := make(map[string]struct{})
+			check := make(map[uint64]struct{})
 			// iterate over items
 			m.Run(func(key, value interface{}) bool {
-				check[key.(string)] = struct{}{}
+				check[key.(uint64)] = struct{}{}
 				// go until no more items
 				return true
 			})


### PR DESCRIPTION
Pros: key length doesn't matter anymore (memory wise).

Cons: risk of collisions and we can't know when a specific key is evicted (this affects `OnEvict`, but probably isn't that important).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/25)
<!-- Reviewable:end -->
