### PR TITLE
bench - show hit ratios and throughput

### DIFF
--- a/bench/bench.go
+++ b/bench/bench.go
@@ -225,14 +225,14 @@ func Labels() []string {
 	return []string{
 		"name       ",
 		"label        ",
-		"gr",
-		"ops   ",
+		"go",
+		" mop/s",
+		" ns/op",
 		"ac",
 		"byt",
 		"hits    ",
 		"misses  ",
 		"  ratio ",
-		"  ns/op   ",
 	}
 }
 
@@ -244,20 +244,41 @@ type Log struct {
 
 // Record generates a CSV record.
 func (l *Log) Record() []string {
+	var (
+		goroutines  string = fmt.Sprintf("%2d", l.Benchmark.Para*l.Result.Procs)
+		mOpsPerSec  string = fmt.Sprintf("%6.2f", l.Result.Ops)
+		allocsPerOp string = fmt.Sprintf("%02d", l.Result.Allocs)
+		bytesPerOp  string = fmt.Sprintf("%03d", l.Result.Bytes)
+		nsPerOp     string = fmt.Sprintf("%6d", l.Result.NsOp)
+		totalHits   string = fmt.Sprintf("%08d", l.Result.Hits)
+		totalMisses string = fmt.Sprintf("%08d", l.Result.Misses)
+		hitRatio    string = fmt.Sprintf("%6.2f%%",
+			100*(float64(l.Result.Hits)/float64(l.Result.Hits+l.Result.Misses)),
+		)
+	)
+	if l.Benchmark.Label[:4] == "hits" {
+		mOpsPerSec = "------"
+		allocsPerOp = "--"
+		bytesPerOp = "---"
+		nsPerOp = "------"
+	} else {
+		totalHits = "--------"
+		totalMisses = "--------"
+		hitRatio = "-------"
+	}
 	return []string{
 		l.Benchmark.Name,
 		l.Benchmark.Label,
-		fmt.Sprintf("%d", l.Benchmark.Para*l.Result.Procs),
-		fmt.Sprintf("%6.2f", l.Result.Ops),
-		fmt.Sprintf("%02d", l.Result.Allocs),
-		fmt.Sprintf("%03d", l.Result.Bytes),
+		// throughput stats
+		goroutines,
+		mOpsPerSec,
+		nsPerOp,
+		allocsPerOp,
+		bytesPerOp,
 		// hit ratio stats
-		fmt.Sprintf("%08d", l.Result.Hits),
-		fmt.Sprintf("%08d", l.Result.Misses),
-		fmt.Sprintf("%6.2f%%",
-			100*(float64(l.Result.Hits)/float64(l.Result.Hits+l.Result.Misses)),
-		),
-		l.Result.NsOp,
+		totalHits,
+		totalMisses,
+		hitRatio,
 	}
 }
 
@@ -275,7 +296,7 @@ type Result struct {
 	Procs  int
 	Hits   int64
 	Misses int64
-	NsOp   string
+	NsOp   int64
 }
 
 // NewResult extracts the data we're interested in from a BenchmarkResult.
@@ -295,7 +316,7 @@ func NewResult(res testing.BenchmarkResult, coll *LogCollection) *Result {
 		Procs:  runtime.GOMAXPROCS(0),
 		Hits:   coll.Hits(),
 		Misses: coll.Misses(),
-		NsOp:   fmt.Sprintf("%10d ns/op", res.NsPerOp()),
+		NsOp:   res.NsPerOp(),
 	}
 }
 

--- a/bench/bench.go
+++ b/bench/bench.go
@@ -75,7 +75,7 @@ type Benchmark struct {
 	Para int
 	// Create is the lazily evaluated function for creating new instances of the
 	// underlying cache.
-	Create func() Cache
+	Create func(hits bool) Cache
 }
 
 func (b *Benchmark) Log() {
@@ -114,9 +114,7 @@ func NewBenchmarks(kind string, para, capa int, cache *benchCache) []*Benchmark 
 			Label:   suite[i].label,
 			Bencher: suite[i].bencher,
 			Para:    para,
-			Create: func() Cache {
-				return cache.create(capa, suite[i].label[:4] == "hits")
-			},
+			Create:  func(hits bool) Cache { return cache.create(capa, hits) },
 		}
 	}
 	return benchmarks

--- a/bench/cache.go
+++ b/bench/cache.go
@@ -42,7 +42,7 @@ type BenchRistretto struct {
 
 func NewBenchRistretto(capacity int, track bool) Cache {
 	c, err := ristretto.NewCache(&ristretto.Config{
-		NumCounters: int64(capacity),
+		NumCounters: int64(capacity * 10),
 		MaxCost:     int64(capacity),
 		Log:         track,
 		BufferItems: int64(capacity) / 16,

--- a/bench/cache.go
+++ b/bench/cache.go
@@ -42,10 +42,10 @@ type BenchRistretto struct {
 
 func NewBenchRistretto(capacity int, track bool) Cache {
 	c, err := ristretto.NewCache(&ristretto.Config{
-		NumCounters: int64(10 * capacity),
+		NumCounters: int64(capacity),
 		MaxCost:     int64(capacity),
 		Log:         track,
-		BufferItems: 5,
+		BufferItems: int64(capacity) / 16,
 	})
 	if err != nil {
 		panic(err)

--- a/bench/generate.go
+++ b/bench/generate.go
@@ -96,13 +96,13 @@ func GetSame(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 func GetZipf(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 	return func(b *testing.B) {
 		cache := bench.Create(false)
-		keys := sim.StringCollection(sim.NewZipfian(zipfS, zipfV, w), w)
+		keys := sim.StringCollection(sim.NewZipfian(zipfS, zipfV, capacity), capacity)
 		b.SetParallelism(bench.Para)
 		b.SetBytes(1)
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for i := uint64(0); pb.Next(); i++ {
-				cache.Get(keys[i&(w-1)])
+				cache.Get(keys[i&(capacity-1)])
 			}
 		})
 	}
@@ -126,14 +126,14 @@ func SetSame(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 func SetZipf(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 	return func(b *testing.B) {
 		cache := bench.Create(false)
-		keys := sim.StringCollection(sim.NewZipfian(zipfS, zipfV, w), w)
+		keys := sim.StringCollection(sim.NewZipfian(zipfS, zipfV, capacity), capacity)
 		vals := []byte("*")
 		b.SetParallelism(bench.Para)
 		b.SetBytes(1)
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for i := uint64(0); pb.Next(); i++ {
-				cache.Set(keys[i&(w-1)], vals)
+				cache.Set(keys[i&(capacity-1)], vals)
 			}
 		})
 	}
@@ -142,7 +142,7 @@ func SetZipf(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 func SetGetZipf(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 	return func(b *testing.B) {
 		cache := bench.Create(false)
-		keys := sim.StringCollection(sim.NewZipfian(zipfS, zipfV, w), w)
+		keys := sim.StringCollection(sim.NewZipfian(zipfS, zipfV, capacity), capacity)
 		vals := []byte("*")
 		b.SetParallelism(bench.Para)
 		b.SetBytes(1)
@@ -151,8 +151,8 @@ func SetGetZipf(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
 				ti := atomic.AddInt32(&i, 1)
-				if _, ok := cache.Get(keys[ti&(w-1)]); !ok {
-					cache.Set(keys[ti&(w-1)], vals)
+				if _, ok := cache.Get(keys[ti&(capacity-1)]); !ok {
+					cache.Set(keys[ti&(capacity-1)], vals)
 				}
 			}
 		})

--- a/bench/generate.go
+++ b/bench/generate.go
@@ -41,7 +41,7 @@ const (
 // HitsUniform records the hit ratio using a uniformly random distribution.
 func HitsUniform(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 	return func(b *testing.B) {
-		cache := bench.Create()
+		cache := bench.Create(true)
 		keys := sim.StringCollection(sim.NewUniform(w), w)
 		vals := []byte("*")
 		b.SetParallelism(bench.Para)
@@ -61,7 +61,7 @@ func HitsUniform(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 // HitsZipf records the hit ratio using a Zipfian distribution.
 func HitsZipf(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 	return func(b *testing.B) {
-		cache := bench.Create()
+		cache := bench.Create(true)
 		keys := sim.StringCollection(sim.NewZipfian(zipfS, zipfV, w), w)
 		vals := []byte("*")
 		b.SetParallelism(bench.Para)
@@ -80,7 +80,7 @@ func HitsZipf(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 
 func GetSame(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 	return func(b *testing.B) {
-		cache := bench.Create()
+		cache := bench.Create(false)
 		cache.Set("*", []byte("*"))
 		b.SetParallelism(bench.Para)
 		b.SetBytes(1)
@@ -95,7 +95,7 @@ func GetSame(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 
 func GetZipf(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 	return func(b *testing.B) {
-		cache := bench.Create()
+		cache := bench.Create(false)
 		keys := sim.StringCollection(sim.NewZipfian(zipfS, zipfV, w), w)
 		b.SetParallelism(bench.Para)
 		b.SetBytes(1)
@@ -110,7 +110,7 @@ func GetZipf(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 
 func SetSame(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 	return func(b *testing.B) {
-		cache := bench.Create()
+		cache := bench.Create(false)
 		data := []byte("*")
 		b.SetParallelism(bench.Para)
 		b.SetBytes(1)
@@ -125,7 +125,7 @@ func SetSame(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 
 func SetZipf(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 	return func(b *testing.B) {
-		cache := bench.Create()
+		cache := bench.Create(false)
 		keys := sim.StringCollection(sim.NewZipfian(zipfS, zipfV, w), w)
 		vals := []byte("*")
 		b.SetParallelism(bench.Para)
@@ -141,7 +141,7 @@ func SetZipf(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 
 func SetGetZipf(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 	return func(b *testing.B) {
-		cache := bench.Create()
+		cache := bench.Create(false)
 		keys := sim.StringCollection(sim.NewZipfian(zipfS, zipfV, w), w)
 		vals := []byte("*")
 		b.SetParallelism(bench.Para)
@@ -163,7 +163,7 @@ func SetGetZipf(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 
 func SetGet(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 	return func(b *testing.B) {
-		cache := bench.Create()
+		cache := bench.Create(false)
 		vals := []byte("*")
 		b.SetParallelism(bench.Para)
 		b.SetBytes(1)

--- a/bench/generate.go
+++ b/bench/generate.go
@@ -150,12 +150,10 @@ func SetGetZipf(bench *Benchmark, coll *LogCollection) func(b *testing.B) {
 		i := int32(0)
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				ti := atomic.LoadInt32(&i)
-				_, ok := cache.Get(keys[ti&(w-1)])
-				if !ok {
+				ti := atomic.AddInt32(&i, 1)
+				if _, ok := cache.Get(keys[ti&(w-1)]); !ok {
 					cache.Set(keys[ti&(w-1)], vals)
 				}
-				atomic.AddInt32(&i, 1)
 			}
 		})
 	}

--- a/bench/sim/sim_test.go
+++ b/bench/sim/sim_test.go
@@ -18,15 +18,30 @@ package sim
 
 import (
 	"bytes"
+	"math"
 	"testing"
 )
 
 func TestZipfian(t *testing.T) {
 	s := NewZipfian(1.25, 2, 100)
+	m := make(map[uint64]uint64, 100)
 	for i := 0; i < 100; i++ {
-		if _, err := s(); err != nil {
+		k, err := s()
+		if err != nil {
 			t.Fatal(err)
 		}
+		m[k]++
+	}
+	maxVal, minVal := uint64(0), uint64(math.MaxUint64)
+	for _, v := range m {
+		if v < minVal {
+			minVal = v
+		} else if v > maxVal {
+			maxVal = v
+		}
+	}
+	if maxVal-minVal < 10 {
+		t.Fatal("zipf not skewed enough")
 	}
 }
 


### PR DESCRIPTION
Updated bench to work with recent changes. Also made some aesthetic changes to `stats.csv` generation for clarity. 

Example `stats.csv` output:

```
name       , label        , go,  mop/s,  ns/op, ac, byt, hits    , misses  ,   ratio
ristretto  , hits-uniform ,  4, ------, ------, --, ---, 00239699, 00770402,  23.73%
ristretto  , hits-zipf    ,  4, ------, ------, --, ---, 02125603, 00884498,  70.62%
ristretto  , get-same     ,  4,  19.24,     51, 00, 008, --------, --------, -------
ristretto  , get-zipf     ,  4,  14.07,     71, 00, 008, --------, --------, -------
ristretto  , set-get      ,  4,   6.17,    162, 01, 032, --------, --------, -------
ristretto  , set-same     ,  4,   4.07,    245, 03, 056, --------, --------, -------
ristretto  , set-zipf     ,  4,   1.28,    782, 05, 089, --------, --------, -------
ristretto  , set-get-zipf ,  4,   1.43,    697, 03, 063, --------, --------, -------
```

Some areas are dashed-out to be less confusing. For example, hit ratio tracking messes with the throughput numbers. I think it's better to keep things separated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/29)
<!-- Reviewable:end -->
