### PR TITLE
Optimize cache.Set operation

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -17,6 +17,7 @@
 package ristretto
 
 import (
+	"fmt"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -500,4 +501,8 @@ func (p *PolicyLog) GetEvictions() int64 {
 func (p *PolicyLog) Ratio() float64 {
 	hits, misses := atomic.LoadInt64(&p.hits), atomic.LoadInt64(&p.miss)
 	return float64(hits) / float64(hits+misses)
+}
+
+func (p *PolicyLog) String() string {
+	return fmt.Sprintf("Hits: %d Miss: %d Evicts: %d", p.GetHits(), p.GetMisses(), p.GetEvictions())
 }

--- a/store.go
+++ b/store.go
@@ -62,7 +62,7 @@ func (m *syncMap) Del(key uint64) {
 	m.Delete(key)
 }
 
-const numShards uint64 = 1024
+const numShards uint64 = 256
 
 type shardedMap struct {
 	shards []*lockedMap

--- a/store_test.go
+++ b/store_test.go
@@ -83,35 +83,5 @@ func GenerateTest(create func() store) func(*testing.T) {
 				t.Fatal("del error")
 			}
 		})
-		t.Run("run", func(t *testing.T) {
-			m := create()
-			n := 10
-			// populate with incrementing ints
-			for i := 0; i < n; i++ {
-				m.Set(uint64(i), i)
-			}
-			// will hold items collected during Run
-			check := make(map[uint64]struct{})
-			// iterate over items
-			m.Run(func(key, value interface{}) bool {
-				check[key.(uint64)] = struct{}{}
-				// go until no more items
-				return true
-			})
-			if len(check) != n {
-				t.Fatal("run not iterating over all elements")
-			}
-			// check stopping run iteration
-			i := 0
-			// iterate 3 times
-			m.Run(func(key, value interface{}) bool {
-				i++
-				return !(i == 3)
-			})
-			if i != 3 {
-				println(i)
-				t.Fatal("run not checking return bool")
-			}
-		})
 	}
 }


### PR DESCRIPTION
Use a channel to buffer up all the Set operations. In case the channel overflows, drop the Set operation on the floor for now. This should be OK for an immutable key-value pair. If the values for a key are mutable, then we can allow a lossless way to do sets later, as needed.

This provides stellar Set performance.

```
$ go test -count=1 -cpu=4,8,16,32,64 -v -bench=BenchmarkCaches              
goos: linux
goarch: amd64
BenchmarkCaches/BigCacheZipfWrite-4          	 5000000	       334 ns/op	      24 B/op	       2 allocs/op
BenchmarkCaches/BigCacheZipfWrite-8          	10000000	       209 ns/op	      34 B/op	       2 allocs/op
BenchmarkCaches/BigCacheZipfWrite-16         	10000000	       137 ns/op	      47 B/op	       2 allocs/op
BenchmarkCaches/BigCacheZipfWrite-32         	20000000	       107 ns/op	      20 B/op	       2 allocs/op
BenchmarkCaches/BigCacheZipfWrite-64         	10000000	       157 ns/op	      15 B/op	       2 allocs/op
BenchmarkCaches/FastCacheZipfWrite-4         	10000000	       173 ns/op	       4 B/op	       1 allocs/op
BenchmarkCaches/FastCacheZipfWrite-8         	20000000	       103 ns/op	       4 B/op	       1 allocs/op
BenchmarkCaches/FastCacheZipfWrite-16        	20000000	        69.7 ns/op	       4 B/op	       1 allocs/op
BenchmarkCaches/FastCacheZipfWrite-32        	30000000	        53.0 ns/op	       4 B/op	       1 allocs/op
BenchmarkCaches/FastCacheZipfWrite-64        	30000000	        51.6 ns/op	       4 B/op	       1 allocs/op
BenchmarkCaches/FreeCacheZipfWrite-4         	 5000000	       326 ns/op	       4 B/op	       1 allocs/op
BenchmarkCaches/FreeCacheZipfWrite-8         	10000000	       186 ns/op	       4 B/op	       1 allocs/op
BenchmarkCaches/FreeCacheZipfWrite-16        	10000000	       117 ns/op	       4 B/op	       1 allocs/op
BenchmarkCaches/FreeCacheZipfWrite-32        	20000000	        72.0 ns/op	       4 B/op	       1 allocs/op
BenchmarkCaches/FreeCacheZipfWrite-64        	20000000	        64.7 ns/op	       4 B/op	       1 allocs/op
BenchmarkCaches/GroupCacheZipfWrite-4        	 5000000	       254 ns/op	      63 B/op	       3 allocs/op
BenchmarkCaches/GroupCacheZipfWrite-8        	10000000	       156 ns/op	      63 B/op	       3 allocs/op
BenchmarkCaches/GroupCacheZipfWrite-16       	20000000	       101 ns/op	      63 B/op	       3 allocs/op
BenchmarkCaches/GroupCacheZipfWrite-32       	20000000	        68.0 ns/op	      63 B/op	       3 allocs/op
BenchmarkCaches/GroupCacheZipfWrite-64       	20000000	        64.9 ns/op	      63 B/op	       4 allocs/op
BenchmarkCaches/RistrettoZipfWrite-4         	10000000	       143 ns/op	      68 B/op	       3 allocs/op
BenchmarkCaches/RistrettoZipfWrite-8         	20000000	        82.8 ns/op	      68 B/op	       3 allocs/op
BenchmarkCaches/RistrettoZipfWrite-16        	20000000	        60.1 ns/op	      68 B/op	       3 allocs/op
BenchmarkCaches/RistrettoZipfWrite-32        	50000000	        37.0 ns/op	      68 B/op	       3 allocs/op
BenchmarkCaches/RistrettoZipfWrite-64        	100000000	        26.6 ns/op	      68 B/op	       3 allocs/op
BenchmarkCaches/SyncMapZipfWrite-4           	 2000000	       944 ns/op	      79 B/op	       4 allocs/op
BenchmarkCaches/SyncMapZipfWrite-8           	 1000000	      1018 ns/op	      79 B/op	       5 allocs/op
BenchmarkCaches/SyncMapZipfWrite-16          	 1000000	      1136 ns/op	      79 B/op	       5 allocs/op
BenchmarkCaches/SyncMapZipfWrite-32          	 1000000	      1169 ns/op	      79 B/op	       5 allocs/op
BenchmarkCaches/SyncMapZipfWrite-64          	 1000000	      1200 ns/op	      79 B/op	       5 allocs/op
PASS
ok  	_/home/mrjn/benchmarks/cachebench	239.840s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/32)
<!-- Reviewable:end -->
