### PR TITLE
Overhaul the stats collection

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -108,10 +108,12 @@ func (c *Cache) Get(key interface{}) (interface{}, bool) {
 	hash := z.KeyToHash(key)
 	c.buffer.Push(hash)
 	val, ok := c.data.Get(hash)
-	if ok {
-		c.stats.Add(hit, 1)
-	} else {
-		c.stats.Add(miss, 1)
+	if c.stats != nil {
+		if ok {
+			c.stats.Add(hit, 1)
+		} else {
+			c.stats.Add(miss, 1)
+		}
 	}
 	return val, ok
 }

--- a/cache.go
+++ b/cache.go
@@ -233,7 +233,9 @@ func (p *metrics) Add(t metricType, hash, delta uint64) {
 		return
 	}
 	valp := p.all[t]
-	idx := (hash % 25) * 10 // Leave space between two counters.
+	// Avoid false sharing by padding at least 64 bytes of space between two
+	// atomic counters which would be incremented.
+	idx := (hash % 25) * 10
 	atomic.AddUint64(valp[idx], delta)
 }
 

--- a/cache.go
+++ b/cache.go
@@ -108,12 +108,10 @@ func (c *Cache) Get(key interface{}) (interface{}, bool) {
 	hash := z.KeyToHash(key)
 	c.buffer.Push(hash)
 	val, ok := c.data.Get(hash)
-	if c.stats != nil {
-		if ok {
-			c.stats.Add(hit, 1)
-		} else {
-			c.stats.Add(miss, 1)
-		}
+	if ok {
+		c.stats.Add(hit, 1)
+	} else {
+		c.stats.Add(miss, 1)
 	}
 	return val, ok
 }

--- a/cache.go
+++ b/cache.go
@@ -261,6 +261,7 @@ func (p *metrics) String() string {
 		t := metricType(i)
 		fmt.Fprintf(&buf, "%s: %d ", stringFor(t), p.Get(t))
 	}
-	fmt.Fprintf(&buf, "gets-total: %d", p.Get(hit)+p.Get(miss))
+	fmt.Fprintf(&buf, "gets-total: %d ", p.Get(hit)+p.Get(miss))
+	fmt.Fprintf(&buf, "hit-ratio: %.2f", p.Ratio())
 	return string(buf.Bytes())
 }

--- a/cache.go
+++ b/cache.go
@@ -263,5 +263,5 @@ func (p *metrics) String() string {
 	}
 	fmt.Fprintf(&buf, "gets-total: %d ", p.Get(hit)+p.Get(miss))
 	fmt.Fprintf(&buf, "hit-ratio: %.2f", p.Ratio())
-	return string(buf.Bytes())
+	return buf.String()
 }

--- a/cache.go
+++ b/cache.go
@@ -213,15 +213,15 @@ func stringFor(t metricType) string {
 // cost to maintaining the counters, so it's best to wrap Policies via the
 // Recorder type when hit ratio analysis is needed.
 type metrics struct {
-	all []*uint64
+	all [doNotUse][256]uint64
 }
 
 func newMetrics() *metrics {
 	s := &metrics{}
-	for i := 0; i < doNotUse; i++ {
-		v := new(uint64)
-		s.all = append(s.all, v)
-	}
+	// for i := 0; i < doNotUse; i++ {
+	// 	v := new(uint64)
+	// 	s.all = append(s.all, v)
+	// }
 	return s
 }
 
@@ -230,7 +230,8 @@ func (p *metrics) Add(t metricType, delta uint64) {
 		return
 	}
 	valp := p.all[t]
-	atomic.AddUint64(valp, delta)
+	idx := z.FastRand() % 256
+	atomic.AddUint64(&valp[idx], delta)
 }
 
 func (p *metrics) Get(t metricType) uint64 {
@@ -238,7 +239,8 @@ func (p *metrics) Get(t metricType) uint64 {
 		return 0
 	}
 	valp := p.all[t]
-	return atomic.LoadUint64(valp)
+	idx := z.FastRand() % 256
+	return atomic.LoadUint64(&valp[idx])
 }
 
 func (p *metrics) Ratio() float64 {

--- a/cache.go
+++ b/cache.go
@@ -180,6 +180,35 @@ const (
 	doNotUse
 )
 
+func stringFor(t metricType) string {
+	switch t {
+	case hit:
+		return "hit"
+	case miss:
+		return "miss"
+	case keyAdd:
+		return "keys-added"
+	case keyUpdate:
+		return "keys-updated"
+	case keyEvict:
+		return "keys-evicted"
+	case costAdd:
+		return "cost-added"
+	case costEvict:
+		return "cost-evicted"
+	case dropSets:
+		return "sets-dropped"
+	case rejectSets:
+		return "sets-rejected" // by policy.
+	case dropGets:
+		return "gets-dropped"
+	case keepGets:
+		return "gets-kept"
+	default:
+		return "unidentified"
+	}
+}
+
 // metrics is the struct for hit ratio statistics. Note that there is some
 // cost to maintaining the counters, so it's best to wrap Policies via the
 // Recorder type when hit ratio analysis is needed.
@@ -221,35 +250,6 @@ func (p *metrics) Ratio() float64 {
 		return 0.0
 	}
 	return float64(hits) / float64(hits+misses)
-}
-
-func stringFor(t metricType) string {
-	switch t {
-	case hit:
-		return "hit"
-	case miss:
-		return "miss"
-	case keyAdd:
-		return "keys-added"
-	case keyUpdate:
-		return "keys-updated"
-	case keyEvict:
-		return "keys-evicted"
-	case costAdd:
-		return "cost-added"
-	case costEvict:
-		return "cost-evicted"
-	case dropSets:
-		return "sets-dropped"
-	case rejectSets:
-		return "sets-rejected" // by policy.
-	case dropGets:
-		return "gets-dropped"
-	case keepGets:
-		return "gets-kept"
-	default:
-		return "unidentified"
-	}
 }
 
 func (p *metrics) String() string {

--- a/cache.go
+++ b/cache.go
@@ -165,8 +165,8 @@ const (
 	keyEvict
 
 	// The following 2 keep track of cost of keys added and evicted.
-	costAdded
-	costEvicted
+	costAdd
+	costEvict
 
 	// The following keep track of how many sets were dropped or rejected later.
 	dropSets
@@ -235,9 +235,9 @@ func stringFor(t metricType) string {
 		return "keys-updated"
 	case keyEvict:
 		return "keys-evicted"
-	case costAdded:
+	case costAdd:
 		return "cost-added"
-	case costEvicted:
+	case costEvict:
 		return "cost-evicted"
 	case dropSets:
 		return "sets-dropped"

--- a/cache_test.go
+++ b/cache_test.go
@@ -194,7 +194,6 @@ func TestCacheSetGet(t *testing.T) {
 	for i := 0; i < 16; i++ {
 		key := fmt.Sprintf("%d", i)
 		if pushed := c.Set(key, i, 1); pushed {
-			time.Sleep(10 * time.Millisecond)
 			value, found := c.Get(key)
 			if found && (value == nil || value.(int) != i) {
 				// There's no guarantee that the key would definitely make it to cache.

--- a/policy.go
+++ b/policy.go
@@ -211,15 +211,18 @@ func (p *sampledLFU) fillSample(in []*policyPair) []*policyPair {
 
 func (p *sampledLFU) del(key uint64) {
 	cost := p.keyCosts[key]
-	p.stats.Add(costAdded, uint64(cost))
+
 	p.stats.Add(keyEvict, 1)
+	p.stats.Add(costEvict, uint64(cost))
+
 	p.used -= cost
 	delete(p.keyCosts, key)
 }
 
 func (p *sampledLFU) add(key uint64, cost int64) {
-	p.stats.Add(costAdded, uint64(cost))
 	p.stats.Add(keyAdd, 1)
+	p.stats.Add(costAdd, uint64(cost))
+
 	p.keyCosts[key] = cost
 	p.used += cost
 }

--- a/policy.go
+++ b/policy.go
@@ -105,7 +105,6 @@ func (p *defaultPolicy) Add(key uint64, cost int64) ([]uint64, bool) {
 		return nil, false
 	}
 	if has := p.evict.updateIfHas(key, cost); has {
-		p.stats.Add(keyUpdate, 1)
 		return nil, true
 	}
 

--- a/policy.go
+++ b/policy.go
@@ -141,8 +141,9 @@ func (p *defaultPolicy) Add(key uint64, cost int64) ([]uint64, bool) {
 				minKey, minHits, minId = pair.key, hits, i
 			}
 		}
-		// if the incoming item isn't worth keeping in the policy, stop
+		// If the incoming item isn't worth keeping in the policy, reject.
 		if incHits < minHits {
+			p.stats.Add(rejectSets, 1)
 			return victims, false
 		}
 		// delete the victim from metadata

--- a/policy.go
+++ b/policy.go
@@ -17,10 +17,8 @@
 package ristretto
 
 import (
-	"fmt"
 	"math"
 	"sync"
-	"sync/atomic"
 
 	"github.com/dgraph-io/ristretto/z"
 )
@@ -44,7 +42,8 @@ type Policy interface {
 	Del(uint64)
 	// Cap returns the available capacity.
 	Cap() int64
-	Log() *PolicyLog
+	// Optionally, set stats object to track how policy is performing.
+	CollectMetrics(stats *stats)
 }
 
 func newPolicy(numCounters, maxCost int64) Policy {
@@ -62,10 +61,14 @@ func newPolicy(numCounters, maxCost int64) Policy {
 // admission with sampledLFU eviction.
 type defaultPolicy struct {
 	sync.Mutex
-	admit *tinyLFU
-	evict *sampledLFU
-
+	admit   *tinyLFU
+	evict   *sampledLFU
 	itemsCh chan []uint64
+	stats   *stats
+}
+
+func (p *defaultPolicy) CollectMetrics(stats *stats) {
+	p.stats = stats
 }
 
 type policyPair struct {
@@ -167,10 +170,6 @@ func (p *defaultPolicy) Cap() int64 {
 	p.Lock()
 	defer p.Unlock()
 	return int64(p.evict.maxCost - p.evict.used)
-}
-
-func (p *defaultPolicy) Log() *PolicyLog {
-	return nil
 }
 
 // sampledLFU is an eviction helper storing key-cost pairs.
@@ -289,7 +288,7 @@ func (p *tinyLFU) reset() {
 type Clairvoyant struct {
 	sync.Mutex
 	time     int64
-	log      *PolicyLog
+	log      *stats
 	access   map[uint64][]int64
 	capacity int64
 	future   []uint64
@@ -297,10 +296,13 @@ type Clairvoyant struct {
 
 func newClairvoyant(numCounters, maxCost int64) Policy {
 	return &Clairvoyant{
-		log:      &PolicyLog{},
 		capacity: numCounters,
 		access:   make(map[uint64][]int64, numCounters),
 	}
+}
+
+func (p *Clairvoyant) CollectMetrics(stats *stats) {
+	p.log = stats
 }
 
 // distance finds the "time distance" from the start position to the minimum
@@ -360,7 +362,7 @@ func (p *Clairvoyant) Cap() int64 {
 	return 0
 }
 
-func (p *Clairvoyant) Log() *PolicyLog {
+func (p *Clairvoyant) Log() *stats {
 	p.Lock()
 	defer p.Unlock()
 	// data serves as the "pseudocache" with the ability to see into the future
@@ -369,10 +371,10 @@ func (p *Clairvoyant) Log() *PolicyLog {
 	for i, key := range p.future {
 		// check if already exists
 		if _, exists := data[key]; exists {
-			p.log.Hit()
+			p.log.Add(hit, 1)
 			continue
 		}
-		p.log.Miss()
+		p.log.Add(miss, 1)
 		// check if eviction is needed
 		if size == p.capacity {
 			// eviction is needed
@@ -386,7 +388,7 @@ func (p *Clairvoyant) Log() *PolicyLog {
 					// there's no good distances because the key isn't used
 					// again in the future, so we can just stop here and delete
 					// it, and skip over the rest
-					p.log.Evict()
+					p.log.Add(evict, 1)
 					delete(data, k)
 					size--
 					goto add
@@ -402,7 +404,7 @@ func (p *Clairvoyant) Log() *PolicyLog {
 				c++
 			}
 			// delete the item furthest away
-			p.log.Evict()
+			p.log.Add(evict, 1)
 			delete(data, maxKey)
 			size--
 		}
@@ -412,97 +414,4 @@ func (p *Clairvoyant) Log() *PolicyLog {
 		size++
 	}
 	return p.log
-}
-
-// recorder is a wrapper type useful for logging policy performance. Because hit
-// ratio tracking adds substantial overhead (either by atomically incrementing
-// counters or using policy-level mutexes), this struct allows us to only incur
-// that overhead when we want to analyze the hit ratio performance.
-type recorder struct {
-	data   store
-	policy Policy
-	log    *PolicyLog
-}
-
-func NewRecorder(policy Policy, data store) Policy {
-	return &recorder{
-		data:   data,
-		policy: policy,
-		log:    &PolicyLog{},
-	}
-}
-
-func (r *recorder) Push(keys []uint64) bool {
-	return r.policy.Push(keys)
-}
-
-func (r *recorder) Add(key uint64, cost int64) ([]uint64, bool) {
-	if _, ok := r.data.Get(key); ok {
-		r.log.Hit()
-	} else {
-		r.log.Miss()
-	}
-	victims, added := r.policy.Add(key, cost)
-	if victims != nil {
-		r.log.Evict()
-	}
-	return victims, added
-}
-
-func (r *recorder) Has(key uint64) bool {
-	return r.policy.Has(key)
-}
-
-func (r *recorder) Del(key uint64) {
-	r.policy.Del(key)
-}
-
-func (r *recorder) Cap() int64 {
-	return r.policy.Cap()
-}
-
-func (r *recorder) Log() *PolicyLog {
-	return r.log
-}
-
-// PolicyLog is the struct for hit ratio statistics. Note that there is some
-// cost to maintaining the counters, so it's best to wrap Policies via the
-// Recorder type when hit ratio analysis is needed.
-type PolicyLog struct {
-	hits      int64
-	miss      int64
-	evictions int64
-}
-
-func (p *PolicyLog) Hit() {
-	atomic.AddInt64(&p.hits, 1)
-}
-
-func (p *PolicyLog) Miss() {
-	atomic.AddInt64(&p.miss, 1)
-}
-
-func (p *PolicyLog) Evict() {
-	atomic.AddInt64(&p.evictions, 1)
-}
-
-func (p *PolicyLog) GetHits() int64 {
-	return atomic.LoadInt64(&p.hits)
-}
-
-func (p *PolicyLog) GetMisses() int64 {
-	return atomic.LoadInt64(&p.miss)
-}
-
-func (p *PolicyLog) GetEvictions() int64 {
-	return atomic.LoadInt64(&p.evictions)
-}
-
-func (p *PolicyLog) Ratio() float64 {
-	hits, misses := atomic.LoadInt64(&p.hits), atomic.LoadInt64(&p.miss)
-	return float64(hits) / float64(hits+misses)
-}
-
-func (p *PolicyLog) String() string {
-	return fmt.Sprintf("Hits: %d Miss: %d Evicts: %d", p.GetHits(), p.GetMisses(), p.GetEvictions())
 }


### PR DESCRIPTION
Make stats collection part of cache and pass it into policy and sampled LFU, so we can track lot more metrics. In particular:

- Number of keys added, updated, evicted.
- Cost of keys added and evicted.
- Sets dropped during channel push and rejected by policy.
- Gets dropped during channel push and kept.

Instead of using decorator pattern, this is using if statements to avoid doing atomic increments if the user is not interested in collecting metrics. I see no impact on performance between these two patterns.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/33)
<!-- Reviewable:end -->
