### PR TITLE
Fix go-vet warnings for unsafe in bloom

### DIFF
--- a/z/bbloom.go
+++ b/z/bbloom.go
@@ -139,7 +139,7 @@ func (bl *Bloom) Size(sz uint64) {
 
 // Clear resets the Bloom filter.
 func (bl *Bloom) Clear() {
-	for i, _ := range bl.bitset {
+	for i := range bl.bitset {
 		bl.bitset[i] = 0
 	}
 }
@@ -168,10 +168,8 @@ type bloomJSONImExport struct {
 // returns the bloomfilter with a bitset populated according to the input []byte.
 func newWithBoolset(bs *[]byte, locs uint64) *Bloom {
 	bloomfilter := NewBloomFilter(float64(len(*bs)<<3), float64(locs))
-	ptr := uintptr(unsafe.Pointer(&bloomfilter.bitset[0]))
-	for _, b := range *bs {
-		*(*uint8)(unsafe.Pointer(ptr)) = b
-		ptr++
+	for i, b := range *bs {
+		*(*uint8)(unsafe.Pointer(uintptr(unsafe.Pointer(&bloomfilter.bitset[0])) + uintptr(i))) = b
 	}
 	return bloomfilter
 }
@@ -192,10 +190,9 @@ func (bl Bloom) JSONMarshal() []byte {
 	bloomImEx := bloomJSONImExport{}
 	bloomImEx.SetLocs = uint64(bl.setLocs)
 	bloomImEx.FilterSet = make([]byte, len(bl.bitset)<<3)
-	ptr := uintptr(unsafe.Pointer(&bl.bitset[0]))
 	for i := range bloomImEx.FilterSet {
-		bloomImEx.FilterSet[i] = *(*byte)(unsafe.Pointer(ptr))
-		ptr++
+		bloomImEx.FilterSet[i] = *(*byte)(unsafe.Pointer(uintptr(unsafe.Pointer(&bl.bitset[0])) +
+			uintptr(i)))
 	}
 	data, err := json.Marshal(bloomImEx)
 	if err != nil {

--- a/z/bbloom_test.go
+++ b/z/bbloom_test.go
@@ -110,5 +110,4 @@ func BenchmarkM_Has(b *testing.B) {
 			bf.Has(hash)
 		}
 	}
-
 }


### PR DESCRIPTION
Fixes https://github.com/dgraph-io/badger/issues/1005

Inspired by https://github.com/AndreasBriese/bbloom/commit/5f4d56d674c24417406771d7d1756c70d33398e3#diff-eebbf48a54279308068f73108bc90f16

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/36)
<!-- Reviewable:end -->
