### PR TITLE
Replace AESHash with MemHash

### DIFF
--- a/doorkeeper_test.go
+++ b/doorkeeper_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestDoorkeeper(t *testing.T) {
 	d := z.NewBloomFilter(float64(1374), 0.01)
-	hash := z.AESHashString("*")
+	hash := z.MemHashString("*")
 	if d.Has(hash) {
 		t.Fatal("item exists but was never added")
 	}

--- a/z/bbloom_test.go
+++ b/z/bbloom_test.go
@@ -31,7 +31,7 @@ func TestM_NumberOfWrongs(t *testing.T) {
 
 	cnt := 0
 	for i := range wordlist1 {
-		hash := AESHash(wordlist1[i])
+		hash := MemHash(wordlist1[i])
 		if !bf.AddIfNotHas(hash) {
 			cnt++
 		}
@@ -47,7 +47,7 @@ func TestM_JSON(t *testing.T) {
 
 	cnt := 0
 	for i := range wordlist1 {
-		hash := AESHash(wordlist1[i])
+		hash := MemHash(wordlist1[i])
 		if !bf.AddIfNotHas(hash) {
 			cnt++
 		}
@@ -60,7 +60,7 @@ func TestM_JSON(t *testing.T) {
 
 	cnt2 := 0
 	for i := range wordlist1 {
-		hash := AESHash(wordlist1[i])
+		hash := MemHash(wordlist1[i])
 		if !bf2.AddIfNotHas(hash) {
 			cnt2++
 		}
@@ -81,7 +81,7 @@ func BenchmarkM_New(b *testing.B) {
 func BenchmarkM_Clear(b *testing.B) {
 	bf = NewBloomFilter(float64(n*10), float64(7))
 	for i := range wordlist1 {
-		hash := AESHash(wordlist1[i])
+		hash := MemHash(wordlist1[i])
 		bf.Add(hash)
 	}
 	b.ResetTimer()
@@ -95,7 +95,7 @@ func BenchmarkM_Add(b *testing.B) {
 	b.ResetTimer()
 	for r := 0; r < b.N; r++ {
 		for i := range wordlist1 {
-			hash := AESHash(wordlist1[i])
+			hash := MemHash(wordlist1[i])
 			bf.Add(hash)
 		}
 	}
@@ -106,7 +106,7 @@ func BenchmarkM_Has(b *testing.B) {
 	b.ResetTimer()
 	for r := 0; r < b.N; r++ {
 		for i := range wordlist1 {
-			hash := AESHash(wordlist1[i])
+			hash := MemHash(wordlist1[i])
 			bf.Has(hash)
 		}
 	}

--- a/z/rtutil.go
+++ b/z/rtutil.go
@@ -40,21 +40,23 @@ type stringStruct struct {
 }
 
 //go:noescape
-//go:linkname aeshash runtime.aeshash
-func aeshash(p unsafe.Pointer, h, s uintptr) uintptr
+//go:linkname memhash runtime.memhash
+func memhash(p unsafe.Pointer, h, s uintptr) uintptr
 
-// AESHash is the hash function used by map, it utilizes available hardware instructions.
+// MemHash is the hash function used by map, it utilizes available hardware instructions(behaves as
+// aeshash if aes instruction is available).
 // NOTE: The hash seed changes for every process. So, this cannot be used as a persistent hash.
-func AESHash(data []byte) uint64 {
+func MemHash(data []byte) uint64 {
 	ss := (*stringStruct)(unsafe.Pointer(&data))
-	return uint64(aeshash(ss.str, 0, uintptr(ss.len)))
+	return uint64(memhash(ss.str, 0, uintptr(ss.len)))
 }
 
-// AESHashString is the hash function used by map, it utilizes available hardware instructions.
+// MemHashString is the hash function used by map, it utilizes available hardware instructions
+// (behaves as aeshash if aes instruction is available).
 // NOTE: The hash seed changes for every process. So, this cannot be used as a persistent hash.
-func AESHashString(str string) uint64 {
+func MemHashString(str string) uint64 {
 	ss := (*stringStruct)(unsafe.Pointer(&str))
-	return uint64(aeshash(ss.str, 0, uintptr(ss.len)))
+	return uint64(memhash(ss.str, 0, uintptr(ss.len)))
 }
 
 // FastRand is a fast thread local random function.

--- a/z/rtutil.go
+++ b/z/rtutil.go
@@ -43,15 +43,15 @@ type stringStruct struct {
 //go:linkname memhash runtime.memhash
 func memhash(p unsafe.Pointer, h, s uintptr) uintptr
 
-// MemHash is the hash function used by map, it utilizes available hardware instructions(behaves as
-// aeshash if aes instruction is available).
+// MemHash is the hash function used by go map, it utilizes available hardware instructions(behaves
+// as aeshash if aes instruction is available).
 // NOTE: The hash seed changes for every process. So, this cannot be used as a persistent hash.
 func MemHash(data []byte) uint64 {
 	ss := (*stringStruct)(unsafe.Pointer(&data))
 	return uint64(memhash(ss.str, 0, uintptr(ss.len)))
 }
 
-// MemHashString is the hash function used by map, it utilizes available hardware instructions
+// MemHashString is the hash function used by go map, it utilizes available hardware instructions
 // (behaves as aeshash if aes instruction is available).
 // NOTE: The hash seed changes for every process. So, this cannot be used as a persistent hash.
 func MemHashString(str string) uint64 {

--- a/z/rtutil_test.go
+++ b/z/rtutil_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/dgryski/go-farm"
 )
 
-func BenchmarkAESHash(b *testing.B) {
+func BenchmarkMemHash(b *testing.B) {
 	buf := make([]byte, 64)
 	rand.Read(buf)
 	for i := 0; i < b.N; i++ {
-		AESHash(buf)
+		MemHash(buf)
 	}
 }
 

--- a/z/z.go
+++ b/z/z.go
@@ -22,11 +22,11 @@ func KeyToHash(key interface{}) uint64 {
 	case uint64:
 		return key.(uint64)
 	case string:
-		return AESHashString(key.(string))
+		return MemHashString(key.(string))
 	case []byte:
-		return AESHash(key.([]byte))
+		return MemHash(key.([]byte))
 	case byte:
-		return AESHash([]byte{key.(byte)})
+		return MemHash([]byte{key.(byte)})
 	case int:
 		return uint64(key.(int))
 	case int32:


### PR DESCRIPTION
Currently we are using AESHash(aeshash in runtime) which uses
aesenc instruction. This can crash restritto if it is running
on a hardware not having this instruction. Go runtime, at init
decides to use memhash if this instruction is not available.
memhash is independent of hardware. memhash on every call,
checks if aeshash can be calculated(based on the availabilty of
aesenc intruction), if yes it uses aeshash. If not, it uses normal flow(memhash).
This commit changes AESHash to MemHash.

Fixes: https://github.com/dgraph-io/badger/issues/980

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/37)
<!-- Reviewable:end -->
