### PR TITLE
Resolve two data races in cache_test.go

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -203,13 +203,13 @@ func TestCacheSetDrops(t *testing.T) {
 		sample := uint64(n * size)
 		cache := newCache(true)
 		keys := sim.Collection(sim.NewUniform(sample), sample)
-		start, finish := &sync.WaitGroup{}, &sync.WaitGroup{}
+		ready, start, finish := &sync.WaitGroup{}, &sync.WaitGroup{}, &sync.WaitGroup{}
+		start.Add(1)
+		ready.Add(n)
 		for i := 0; i < n; i++ {
-			start.Add(1)
 			finish.Add(1)
 			go func(i int) {
-				start.Done()
-				// wait for all goroutines to be ready
+				ready.Done()
 				start.Wait()
 				for j := i * size; j < (i*size)+size; j++ {
 					cache.Set(keys[j], 0, 1)
@@ -217,6 +217,11 @@ func TestCacheSetDrops(t *testing.T) {
 				finish.Done()
 			}(i)
 		}
+
+		// wait for all goroutines to be ready
+		ready.Wait()
+		start.Done()
+
 		finish.Wait()
 		dropped := cache.Metrics().Get(dropSets)
 		t.Logf("%d goroutines: %.2f%% dropped \n",

--- a/cache_test.go
+++ b/cache_test.go
@@ -123,6 +123,8 @@ func TestCacheOnEvict(t *testing.T) {
 		cache.Set(i, i, 1)
 	}
 	time.Sleep(time.Second / 100)
+	mu.Lock()
+	defer mu.Unlock()
 	if len(evictions) != 156 {
 		t.Fatal("onEvict not being called")
 	}


### PR DESCRIPTION
### cache_test.go: TestCacheOnEvict() - lock map to prevent datarace

Previously on slow test runs we could read the length and items of a
map while it was still mutating triggering the race detector, this
patch resolves that immediate problem.

There is still the general problem of the tests being sensitive to
timing, owing to time.Sleep commonly being used as a sychronization
mechanism.

```
$ go test -race
==================
WARNING: DATA RACE
Read at 0x00c00009a2d0 by goroutine 8:
  github.com/dgraph-io/ristretto.TestCacheOnEvict()
      /home/r/ristretto/cache_test.go:126 +0x249
  testing.tRunner()
      /home/r/go/src/testing/testing.go:909 +0x199

Previous write at 0x00c00009a2d0 by goroutine 11:
  runtime.mapassign_fast64()
      /home/r/go/src/runtime/map_fast64.go:92 +0x0
  github.com/dgraph-io/ristretto.TestCacheOnEvict.func1()
      /home/r/ristretto/cache_test.go:116 +0xf8
  github.com/dgraph-io/ristretto.(*Cache).processItems()
      /home/r/ristretto/cache.go:200 +0x2a0
```

### cache_test.go: TestCacheSetDrops() - remove sync.WaitGroup data race

I /think/ we might have been violating this constraint:
`func (wg *WaitGroup) Add(delta int)...calls with a positive delta
that occur when the counter is zero must happen before a Wait.`
-- https://golang.org/pkg/sync/#WaitGroup.Wait

The goroutine start sychronisation could have been more simply
achieved with just a channel, but I suspected the there might be a
performance reason for originally using a wg so we keep with that
theme.

For what it's worth, the sychronisation mechanism, be it this way,
just a channel, or if it is removed completely, didn't seem to change
my results for this test.

```
WARNING: DATA RACE
Read at 0x00c0003ed878 by goroutine 47:
  sync.(*WaitGroup).Add()
      /home/r/go/src/internal/race/race.go:37 +0x18d
  github.com/dgraph-io/ristretto.TestCacheSetDrops()
      /home/r/ristretto/cache_test.go:206 +0x68
  testing.tRunner()
      /home/r/go/src/testing/testing.go:909 +0x199

Previous write at 0x00c0003ed878 by goroutine 102:
  sync.(*WaitGroup).Wait()
      /home/r/go/src/internal/race/race.go:41 +0xee
  github.com/dgraph-io/ristretto.TestCacheSetDrops.func1()
      /home/r/ristretto/cache_test.go:211 +0x54

Goroutine 47 (running) created at:
  testing.(*T).Run()
      /home/r/go/src/testing/testing.go:960 +0x651
  testing.runTests.func1()
      /home/r/go/src/testing/testing.go:1202 +0xa6
  testing.tRunner()
      /home/r/go/src/testing/testing.go:909 +0x199
  testing.runTests()
      /home/r/go/src/testing/testing.go:1200 +0x521
  testing.(*M).Run()
      /home/r/go/src/testing/testing.go:1117 +0x2ff
  main.main()
      _testmain.go:84 +0x223
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/54)
<!-- Reviewable:end -->
