### PR TITLE
Add support for custom KeyToHash function

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -149,10 +149,6 @@ func TestCacheKeyToHash(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	intList := make([]int, 0, 10)
-	for i := 0; i < 10; i++ {
-		intList = append(intList, i)
-	}
 	for i := 0; i < 10; i++ {
 		if uint64(i+2) != cache.keyHash(i) {
 			t.Fatal("keyToHash hash mismatch")

--- a/cache_test.go
+++ b/cache_test.go
@@ -24,8 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/dgraph-io/ristretto/sim"
 )
 
@@ -143,7 +141,7 @@ func TestCacheKeyToHash(t *testing.T) {
 		KeyToHash: func(key interface{}) uint64 {
 			i, ok := key.(int)
 			if !ok {
-				panic("unable to type assert")
+				panic("failed to type assert")
 			}
 			return uint64(i + 2)
 		},
@@ -155,9 +153,10 @@ func TestCacheKeyToHash(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		intList = append(intList, i)
 	}
-
 	for i := 0; i < 10; i++ {
-		require.Equal(t, uint64(i+2), cache.keyHash(i))
+		if uint64(i+2) != cache.keyHash(i) {
+			t.Fatal("keyToHash hash mismatch")
+		}
 	}
 }
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/ristretto/sim"
 )
 
@@ -130,6 +132,32 @@ func TestCacheOnEvict(t *testing.T) {
 		if k != uint64(v) {
 			t.Fatal("onEvict key-val mismatch")
 		}
+	}
+}
+
+func TestCacheKeyToHash(t *testing.T) {
+	cache, err := NewCache(&Config{
+		NumCounters: 1000,
+		MaxCost:     100,
+		BufferItems: 1,
+		KeyToHash: func(key interface{}) uint64 {
+			i, ok := key.(int)
+			if !ok {
+				panic("unable to type assert")
+			}
+			return uint64(i + 2)
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	intList := make([]int, 0, 10)
+	for i := 0; i < 10; i++ {
+		intList = append(intList, i)
+	}
+
+	for i := 0; i < 10; i++ {
+		require.Equal(t, uint64(i+2), cache.keyHash(i))
 	}
 }
 


### PR DESCRIPTION
This commit adds support for custom function for key hashing. The key
hash is used for insertion/deletion of items from the cache.

Fixes https://github.com/dgraph-io/ristretto/issues/50

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/55)
<!-- Reviewable:end -->
