### PR TITLE
fix cache del test

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -248,13 +248,16 @@ func TestCacheDel(t *testing.T) {
 	for b := 0; b < capacity/100; b++ {
 		wg.Add(1)
 		go func(b int) {
-			for i := 100 * b; i < 100 * b + 100; i++ {
+			for i := 100 * b; i < 100*b+100; i++ {
 				cache.Del(i)
 			}
 			wg.Done()
 		}(b)
 	}
 	wg.Wait()
+
+	// wait for Dels to be processed (they pass through the same buffer as Set)
+	time.Sleep(time.Second / 100)
 
 	for key := 0; key < capacity; key++ {
 		if _, ok := cache.Get(key); ok {


### PR DESCRIPTION
Because Del calls are now sent through the same buffer as Sets, we need to wait a few milliseconds after Del for them to be processed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/70)
<!-- Reviewable:end -->
