### PR TITLE
refactor(valName): local variable name same with global struct

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -365,9 +365,6 @@ func (p *lruPolicy) Add(key uint64, cost int64) ([]*item, bool) {
 	}
 	victims := make([]*item, 0)
 	incHits := p.admit.Estimate(key)
-	if p.room >= 0 {
-		goto add
-	}
 	for p.room < 0 {
 		lru := p.vals.Back()
 		victim := lru.Value.(*lruItem)
@@ -386,10 +383,9 @@ func (p *lruPolicy) Add(key uint64, cost int64) ([]*item, bool) {
 		// adjust room
 		p.room += victim.cost
 	}
-add:
-	lItem := &lruItem{key: key, cost: cost}
-	lItem.ptr = p.vals.PushFront(lItem)
-	p.ptrs[key] = lItem
+	newItem := &lruItem{key: key, cost: cost}
+	newItem.ptr = p.vals.PushFront(newItem)
+	p.ptrs[key] = newItem
 	p.room -= cost
 	return victims, true
 }

--- a/policy.go
+++ b/policy.go
@@ -387,9 +387,9 @@ func (p *lruPolicy) Add(key uint64, cost int64) ([]*item, bool) {
 		p.room += victim.cost
 	}
 add:
-	item := &lruItem{key: key, cost: cost}
-	item.ptr = p.vals.PushFront(item)
-	p.ptrs[key] = item
+	lItem := &lruItem{key: key, cost: cost}
+	lItem.ptr = p.vals.PushFront(lItem)
+	p.ptrs[key] = lItem
 	p.room -= cost
 	return victims, true
 }


### PR DESCRIPTION
Hi,  `policy.go:L389` use `item` as variable which is conflict with `cache.go:L96`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/71)
<!-- Reviewable:end -->
