### PR TITLE
immediate Updates and lazy cost evaluation

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -92,9 +92,9 @@ type Config struct {
 	// Each key will be hashed using the provided function. If keyToHash value
 	// is not set, the default keyToHash function is used.
 	KeyToHash func(key interface{}) uint64
-	// Coster is called when a new item passed to Set has a cost of 0. The
-	// output of Coster is set as the cost of the new item before it is sent
-	// to the Policy and stored.
+	// Coster evaluates a value and outputs a corresponding cost. This function
+	// is ran after Set is called for a new item or an item update with a cost
+	// param of 0.
 	Coster func(value interface{}) int64
 }
 
@@ -177,6 +177,10 @@ func (c *Cache) Get(key interface{}) (interface{}, bool) {
 // it returns true, there's still a chance it could be dropped by the policy if
 // its determined that the key-value item isn't worth keeping, but otherwise the
 // item will be added and other items will be evicted in order to make room.
+//
+// To dynamically evaluate the items cost using the Config.Coster function, set
+// the cost parameter to 0 and Coster will be ran when needed in order to find
+// the items true cost.
 func (c *Cache) Set(key, value interface{}, cost int64) bool {
 	if c == nil {
 		return false

--- a/cache_test.go
+++ b/cache_test.go
@@ -115,13 +115,13 @@ func TestCacheSetDel(t *testing.T) {
 }
 
 func TestCacheCoster(t *testing.T) {
-	costerRuns := uint64(0)
+	costRuns := uint64(0)
 	cache, err := NewCache(&Config{
 		NumCounters: 1000,
 		MaxCost:     500,
 		BufferItems: 64,
-		Coster: func(value interface{}) int64 {
-			atomic.AddUint64(&costerRuns, 1)
+		Cost: func(value interface{}) int64 {
+			atomic.AddUint64(&costRuns, 1)
 			return 5
 		},
 	})
@@ -137,7 +137,7 @@ func TestCacheCoster(t *testing.T) {
 			t.Fatal("coster not being ran")
 		}
 	}
-	if costerRuns != 100 {
+	if costRuns != 100 {
 		t.Fatal("coster not being ran")
 	}
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -160,6 +160,8 @@ func TestCacheUpdate(t *testing.T) {
 			t.Fatal("keyUpdate value inconsistent")
 		}
 	}
+	// wait for keyUpdates to go through
+	time.Sleep(time.Second / 100)
 	if cache.Metrics().Get(keyUpdate) == 0 {
 		t.Fatal("keyUpdates not being processed")
 	}

--- a/policy.go
+++ b/policy.go
@@ -257,6 +257,8 @@ func (p *sampledLFU) add(key uint64, cost int64) {
 
 func (p *sampledLFU) updateIfHas(key uint64, cost int64) bool {
 	if prev, found := p.keyCosts[key]; found {
+		// update the cost of an existing key, but don't worry about evicting,
+		// evictions will be handled the next time a new item is added
 		p.stats.Add(keyUpdate, key, 1)
 		p.used += cost - prev
 		p.keyCosts[key] = cost

--- a/policy.go
+++ b/policy.go
@@ -170,27 +170,28 @@ func (p *defaultPolicy) Add(key uint64, cost int64) ([]*item, bool) {
 
 func (p *defaultPolicy) Has(key uint64) bool {
 	p.Lock()
-	defer p.Unlock()
 	_, exists := p.evict.keyCosts[key]
+	p.Unlock()
 	return exists
 }
 
 func (p *defaultPolicy) Del(key uint64) {
 	p.Lock()
-	defer p.Unlock()
 	p.evict.del(key)
+	p.Unlock()
 }
 
 func (p *defaultPolicy) Cap() int64 {
 	p.Lock()
-	defer p.Unlock()
-	return int64(p.evict.maxCost - p.evict.used)
+	capacity := int64(p.evict.maxCost - p.evict.used)
+	p.Unlock()
+	return capacity
 }
 
 func (p *defaultPolicy) Update(key uint64, cost int64) {
 	p.Lock()
-	defer p.Unlock()
 	p.evict.updateIfHas(key, cost)
+	p.Unlock()
 }
 
 func (p *defaultPolicy) Cost(key uint64) int64 {
@@ -239,10 +240,8 @@ func (p *sampledLFU) del(key uint64) {
 	if !ok {
 		return
 	}
-
 	p.stats.Add(keyEvict, key, 1)
 	p.stats.Add(costEvict, key, uint64(cost))
-
 	p.used -= cost
 	delete(p.keyCosts, key)
 }
@@ -250,7 +249,6 @@ func (p *sampledLFU) del(key uint64) {
 func (p *sampledLFU) add(key uint64, cost int64) {
 	p.stats.Add(keyAdd, key, 1)
 	p.stats.Add(costAdd, key, uint64(cost))
-
 	p.keyCosts[key] = cost
 	p.used += cost
 }

--- a/policy.go
+++ b/policy.go
@@ -43,6 +43,10 @@ type policy interface {
 	Del(uint64)
 	// Cap returns the available capacity.
 	Cap() int64
+	// Update updates the cost value for the key.
+	Update(uint64, int64)
+	// Cost returns the cost value of a key or -1 if missing.
+	Cost(uint64) int64
 	// Optionally, set stats object to track how policy is performing.
 	CollectMetrics(stats *metrics)
 }
@@ -157,9 +161,7 @@ func (p *defaultPolicy) Add(key uint64, cost int64) ([]*item, bool) {
 		// store victim in evicted victims slice
 		victims = append(victims, &item{
 			key:  minKey,
-			val:  nil,
 			cost: minCost,
-			del:  false,
 		})
 	}
 	p.evict.add(key, cost)
@@ -183,6 +185,21 @@ func (p *defaultPolicy) Cap() int64 {
 	p.Lock()
 	defer p.Unlock()
 	return int64(p.evict.maxCost - p.evict.used)
+}
+
+func (p *defaultPolicy) Update(key uint64, cost int64) {
+	p.Lock()
+	defer p.Unlock()
+	p.evict.updateIfHas(key, cost)
+}
+
+func (p *defaultPolicy) Cost(key uint64) int64 {
+	p.Lock()
+	defer p.Unlock()
+	if cost, found := p.evict.keyCosts[key]; found {
+		return cost
+	}
+	return -1
 }
 
 // sampledLFU is an eviction helper storing key-cost pairs.
@@ -238,11 +255,8 @@ func (p *sampledLFU) add(key uint64, cost int64) {
 	p.used += cost
 }
 
-// TODO: Move this to the store itself. So, it can be used by public Set.
-func (p *sampledLFU) updateIfHas(key uint64, cost int64) (updated bool) {
-	if prev, exists := p.keyCosts[key]; exists {
-		// Update the cost of the existing key. For simplicity, don't worry about evicting anything
-		// if the updated cost causes the size to grow beyond maxCost.
+func (p *sampledLFU) updateIfHas(key uint64, cost int64) bool {
+	if prev, found := p.keyCosts[key]; found {
 		p.stats.Add(keyUpdate, key, 1)
 		p.used += cost - prev
 		p.keyCosts[key] = cost
@@ -376,9 +390,7 @@ func (p *lruPolicy) Add(key uint64, cost int64) ([]*item, bool) {
 		delete(p.ptrs, victim.key)
 		victims = append(victims, &item{
 			key:  victim.key,
-			val:  nil,
 			cost: victim.cost,
-			del:  false,
 		})
 		// adjust room
 		p.room += victim.cost
@@ -410,6 +422,15 @@ func (p *lruPolicy) Cap() int64 {
 	p.Lock()
 	defer p.Unlock()
 	return int64(p.vals.Len())
+}
+
+// TODO
+func (p *lruPolicy) Update(key uint64, cost int64) {
+}
+
+// TODO
+func (p *lruPolicy) Cost(key uint64) int64 {
+	return -1
 }
 
 // TODO

--- a/store.go
+++ b/store.go
@@ -89,21 +89,21 @@ func newLockedMap() *lockedMap {
 
 func (m *lockedMap) Get(key uint64) (interface{}, bool) {
 	m.RLock()
-	defer m.RUnlock()
 	val, found := m.data[key]
+	m.RUnlock()
 	return val, found
 }
 
 func (m *lockedMap) Set(key uint64, value interface{}) {
 	m.Lock()
-	defer m.Unlock()
 	m.data[key] = value
+	m.Unlock()
 }
 
 func (m *lockedMap) Del(key uint64) {
 	m.Lock()
-	defer m.Unlock()
 	delete(m.data, key)
+	m.Unlock()
 }
 
 func (m *lockedMap) Update(key uint64, value interface{}) bool {

--- a/store.go
+++ b/store.go
@@ -34,32 +34,14 @@ type store interface {
 	Set(uint64, interface{})
 	// Del deletes the key-value pair from the Map.
 	Del(uint64)
+	// Update attempts to update the key with a new value and returns true if
+	// successful.
+	Update(uint64, interface{}) bool
 }
 
 // newStore returns the default store implementation.
 func newStore() store {
-	// return newSyncMap()
 	return newShardedMap()
-}
-
-type syncMap struct {
-	*sync.Map
-}
-
-func newSyncMap() store {
-	return &syncMap{&sync.Map{}}
-}
-
-func (m *syncMap) Get(key uint64) (interface{}, bool) {
-	return m.Load(key)
-}
-
-func (m *syncMap) Set(key uint64, value interface{}) {
-	m.Store(key, value)
-}
-
-func (m *syncMap) Del(key uint64) {
-	m.Delete(key)
 }
 
 const numShards uint64 = 256
@@ -91,6 +73,11 @@ func (sm *shardedMap) Del(key uint64) {
 	sm.shards[idx].Del(key)
 }
 
+func (sm *shardedMap) Update(key uint64, value interface{}) bool {
+	idx := key % numShards
+	return sm.shards[idx].Update(key, value)
+}
+
 type lockedMap struct {
 	sync.RWMutex
 	data map[uint64]interface{}
@@ -117,4 +104,14 @@ func (m *lockedMap) Del(key uint64) {
 	m.Lock()
 	defer m.Unlock()
 	delete(m.data, key)
+}
+
+func (m *lockedMap) Update(key uint64, value interface{}) bool {
+	m.Lock()
+	defer m.Unlock()
+	if _, found := m.data[key]; found {
+		m.data[key] = value
+		return true
+	}
+	return false
 }

--- a/store_test.go
+++ b/store_test.go
@@ -20,10 +20,6 @@ import (
 	"testing"
 )
 
-func BenchmarkStoreSyncMap(b *testing.B) {
-	GenerateBench(func() store { return newSyncMap() })(b)
-}
-
 func BenchmarkStoreLockedMap(b *testing.B) {
 	GenerateBench(func() store { return newLockedMap() })(b)
 }
@@ -46,10 +42,6 @@ func GenerateBench(create func() store) func(*testing.B) {
 
 func TestStore(t *testing.T) {
 	GenerateTest(func() store { return newStore() })(t)
-}
-
-func TestStoreSyncMap(t *testing.T) {
-	GenerateTest(func() store { return newSyncMap() })(t)
 }
 
 func TestStoreLockedMap(t *testing.T) {
@@ -81,6 +73,22 @@ func GenerateTest(create func() store) func(*testing.T) {
 			m.Del(1)
 			if val, found := m.Get(1); val != nil || found {
 				t.Fatal("del error")
+			}
+		})
+		t.Run("update", func(t *testing.T) {
+			m := create()
+			m.Set(1, 1)
+			if updated := m.Update(1, 2); !updated {
+				t.Fatal("value should have been updated")
+			}
+			if val, _ := m.Get(1); val.(int) != 2 {
+				t.Fatal("value wasn't updated")
+			}
+			if updated := m.Update(2, 2); updated {
+				t.Fatal("value should not have been updated")
+			}
+			if val, found := m.Get(2); val != nil || found {
+				t.Fatal("value should not have been updated")
 			}
 		})
 	}


### PR DESCRIPTION
This PR addresses the Set/Del race condition by putting Dels on the same internal buffer, as well as immediately updating Set values and eventually updating the corresponding cost.

Costs can also now be calculated using the `config.Coster` function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/75)
<!-- Reviewable:end -->
