### PR TITLE
remove dependency testify

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://gocover.io/github.com/dgraph-io/ristretto)
 ![Tests](https://github.com/dgraph-io/ristretto/workflows/tests/badge.svg)
 
-
 Ristretto is a fast, concurrent cache library built with a focus on performance and correctness.
 
 The motivation to build Ristretto comes from the need for a contention-free

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,4 @@ module github.com/dgraph-io/ristretto
 
 go 1.12
 
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
-	github.com/stretchr/testify v1.3.0
-)
+require github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,2 @@
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/z/z_test.go
+++ b/z/z_test.go
@@ -19,16 +19,20 @@ package z
 import (
 	"math"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
+func verifyHashProduct(t *testing.T, wants, got uint64) {
+	if wants != got {
+		t.Errorf("expected hash product to equal %d. Got %d", wants, got)
+	}
+}
+
 func TestKeyToHash(t *testing.T) {
-	require.Equal(t, uint64(1), KeyToHash(uint64(1)))
-	require.Equal(t, uint64(1), KeyToHash(1))
-	require.Equal(t, uint64(2), KeyToHash(int32(2)))
-	require.Equal(t, uint64(math.MaxUint64)-1, KeyToHash(int32(-2)))
-	require.Equal(t, uint64(math.MaxUint64)-1, KeyToHash(int64(-2)))
-	require.Equal(t, uint64(3), KeyToHash(uint32(3)))
-	require.Equal(t, uint64(3), KeyToHash(int64(3)))
+	verifyHashProduct(t, 1, KeyToHash(uint64(1)))
+	verifyHashProduct(t, 1, KeyToHash(1))
+	verifyHashProduct(t, 2, KeyToHash(int32(2)))
+	verifyHashProduct(t, math.MaxUint64-1, KeyToHash(int32(-2)))
+	verifyHashProduct(t, math.MaxUint64-1, KeyToHash(int64(-2)))
+	verifyHashProduct(t, 3, KeyToHash(uint32(3)))
+	verifyHashProduct(t, 3, KeyToHash(int64(3)))
 }


### PR DESCRIPTION
I noticed that two dependencies can easily be removed by adjusting 7 lines of code. This also removes the redundant uint64 casting as by default, consts are untyped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/89)
<!-- Reviewable:end -->
