### PR TITLE
stats Clear race condition fix

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -239,8 +239,8 @@ func (c *Cache) Clear() {
 	c.policy.Clear()
 	c.store.Clear()
 	// only reset metrics if they're enabled
-	if c.stats != nil {
-		c.stats.Clear()
+	if c.Metrics != nil {
+		c.Metrics.Clear()
 	}
 	// restart processItems goroutine
 	go c.processItems()
@@ -466,7 +466,7 @@ func (p *Metrics) Clear() {
 		}
 	}
 }
-  
+
 func (p *Metrics) String() string {
 	if p == nil {
 		return ""

--- a/cache.go
+++ b/cache.go
@@ -238,7 +238,7 @@ func (c *Cache) Clear() {
 	c.store.Clear()
 	// only reset metrics if they're enabled
 	if c.stats != nil {
-		c.collectMetrics()
+		c.stats.Clear()
 	}
 	// restart processItems goroutine
 	go c.processItems()
@@ -426,4 +426,15 @@ func (p *metrics) Ratio() float64 {
 		return 0.0
 	}
 	return float64(hits) / float64(hits+misses)
+}
+
+func (p *metrics) Clear() {
+	if p == nil {
+		return
+	}
+	for i := 0; i < doNotUse; i++ {
+		for j := range p.all[i] {
+			atomic.StoreUint64(p.all[i][j], 0)
+		}
+	}
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -296,3 +296,32 @@ func TestMetricsExport(t *testing.T) {
 		t.Fatal("exportMetrics wrong value(s)")
 	}
 }
+
+func TestCacheMetricsClear(t *testing.T) {
+	c, err := NewCache(&Config{
+		NumCounters: 100,
+		MaxCost:     10,
+		BufferItems: 64,
+		Metrics:     true,
+	})
+	if err != nil {
+		panic(err)
+	}
+	c.Set(1, 1, 1)
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				c.Get(1)
+			}
+		}
+	}()
+	time.Sleep(wait)
+	c.Clear()
+	stop <- struct{}{}
+	c.stats = nil
+	c.stats.Clear()
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -328,6 +328,6 @@ func TestCacheMetricsClear(t *testing.T) {
 	time.Sleep(wait)
 	c.Clear()
 	stop <- struct{}{}
-	c.stats = nil
-	c.stats.Clear()
+	c.Metrics = nil
+	c.Metrics.Clear()
 }


### PR DESCRIPTION
Along with a small fix, I added `TestCacheMetricsClear` to simulate what I perceived as the issue in #92, which is:

**Goroutine 1:** Continuously calling cache.Get (incrementing metrics counters atomically)
**Goroutine 2:** Calls cache.Clear (calls collectMetrics() which creates a new metrics object and replaces the pointer in cache instance)

The simplest solution I could think of is reserving the collectMetrics() function for initialization, which performs well, but for the cache.Clear operation we should use the same metrics object and atomically zero all counters. This will allow us to keep the performance benefits of using a single atomic operation for metrics.Add calls and not having to use a mutex or channel.

The downside to this solution is the possibility of metric inaccuracies because of the iterative nature of the metrics.Clear operation. Because metrics.Clear is not a single atomic operation, parallel calls to metrics.Add will continue to mutate the metrics object while it's being zeroed.

I do not foresee this downside causing any issues in the future because it would only occur in situations where cache.Clear is being called in parallel with other cache operations, so the user has presumably given up the expectation of fully accurate metrics and would be unable to measure the accuracy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/93)
<!-- Reviewable:end -->
