### PR TITLE
atomic Get-Delete operation for eviction

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -273,16 +273,12 @@ func (c *Cache) processItems() {
 					c.store.Set(i.keyHash, i.key, i.value)
 					// delete victims
 					for _, victim := range victims {
-						// TODO: make Get-Delete atomic
-						if c.onEvict != nil {
-							// force get with no collision checking because
-							// we don't have access to the victim's key
-							victim.value, _ = c.store.Get(victim.keyHash, nil)
-							c.onEvict(victim.keyHash, victim.value, victim.cost)
-						}
 						// force delete with no collision checking because we
 						// don't have access to the original, unhashed key
-						c.store.Del(victim.keyHash, nil)
+						victim.value = c.store.Del(victim.keyHash, nil)
+						if c.onEvict != nil {
+							c.onEvict(victim.keyHash, victim.value, victim.cost)
+						}
 					}
 				}
 			case itemUpdate:

--- a/ring.go
+++ b/ring.go
@@ -62,8 +62,7 @@ func (s *ringStripe) Push(item uint64) {
 // This implements the "batching" process described in the BP-Wrapper paper
 // (section III part A).
 type ringBuffer struct {
-	stripes []*ringStripe
-	pool    *sync.Pool
+	pool *sync.Pool
 }
 
 // newRingBuffer returns a striped ring buffer. The Consumer in ringConfig will


### PR DESCRIPTION
Since we're now using `shardedMap` and have control over the mutex, it's possible to make the Get-Delete operation atomic. This only really affects the `OnEvict` callback.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/94)
<!-- Reviewable:end -->
