### PR TITLE
default to 128bit hashing for collision checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Ristretto is usable but still under active development. We expect it to be produ
 		* [OnEvict](#Config)
 		* [KeyToHash](#Config)
         * [Cost](#Config)
-        * [Hashes](#Config)
 * [Benchmarks](#Benchmarks)
 	* [Hit Ratios](#Hit-Ratios)
 		* [Search](#Search)
@@ -109,13 +108,17 @@ If for some reason you see Get performance decreasing with lots of contention (y
 
 Metrics is true when you want real-time logging of a variety of stats. The reason this is a Config flag is because there's a 10% throughput performance overhead. 
 
-**OnEvict** `func(keyHash uint64, value interface{}, cost int64)`
+**OnEvict** `func(hashes [2]uint64, value interface{}, cost int64)`
 
 OnEvict is called for every eviction.
 
-**KeyToHash** `func(key interface{}) uint64`
+**KeyToHash** `func(key interface{}) [2]uint64`
 
 KeyToHash is the hashing algorithm used for every key. If this is nil, Ristretto has a variety of [defaults depending on the underlying interface type](https://github.com/dgraph-io/ristretto/blob/master/z/z.go#L19-L41).
+
+Note that if you want 128bit hashes you should use the full `[2]uint64`,
+otherwise just fill the `uint64` at the `0` position and it will behave like
+any 64bit hash.
 
 **Cost** `func(value interface{}) int64`
 
@@ -128,15 +131,6 @@ To signal to Ristretto that you'd like to use this Cost function:
 
 1. Set the Cost field to a non-nil function.
 2. When calling Set for new items or item updates, use a `cost` of 0.
-
-**Hashes** `uint8`
-
-Hashes is the number of 64-bit hashes to chain and use as unique identifiers.
-For example, if Hashes is 2, Ristretto will use 128-bit hashes to verify and
-protect against collisions. If Hashes is 3, Ristretto will use 192-bit hashes,
-etc.
-
-If this value is 0 or 1, 64-bit hashes will be used.
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Ristretto is usable but still under active development. We expect it to be produ
 		* [Metrics](#Config)
 		* [OnEvict](#Config)
 		* [KeyToHash](#Config)
+        * [Cost](#Config)
+        * [Hashes](#Config)
 * [Benchmarks](#Benchmarks)
 	* [Hit Ratios](#Hit-Ratios)
 		* [Search](#Search)
@@ -114,6 +116,27 @@ OnEvict is called for every eviction.
 **KeyToHash** `func(key interface{}) uint64`
 
 KeyToHash is the hashing algorithm used for every key. If this is nil, Ristretto has a variety of [defaults depending on the underlying interface type](https://github.com/dgraph-io/ristretto/blob/master/z/z.go#L19-L41).
+
+**Cost** `func(value interface{}) int64`
+
+Cost is an optional function you can pass to the Config in order to evaluate
+item cost at runtime, and only for the Set calls that aren't dropped (this is
+useful if calculating item cost is particularly expensive and you don't want to
+waste time on items that will be dropped anyways).
+
+To signal to Ristretto that you'd like to use this Cost function:
+
+1. Set the Cost field to a non-nil function.
+2. When calling Set for new items or item updates, use a `cost` of 0.
+
+**Hashes** `uint8`
+
+Hashes is the number of 64-bit hashes to chain and use as unique identifiers.
+For example, if Hashes is 2, Ristretto will use 128-bit hashes to verify and
+protect against collisions. If Hashes is 3, Ristretto will use 192-bit hashes,
+etc.
+
+If this value is 0 or 1, 64-bit hashes will be used.
 
 ## Benchmarks
 

--- a/cache.go
+++ b/cache.go
@@ -48,11 +48,11 @@ type Cache struct {
 	// contention
 	setBuf chan *item
 	// onEvict is called for item evictions
-	onEvict func(uint64, interface{}, int64)
+	onEvict func([2]uint64, interface{}, int64)
 	// KeyToHash function is used to customize the key hashing algorithm.
 	// Each key will be hashed using the provided function. If keyToHash value
 	// is not set, the default keyToHash function is used.
-	keyToHash func(interface{}, uint8) uint64
+	keyToHash func(interface{}) [2]uint64
 	// stop is used to stop the processItems goroutine
 	stop chan struct{}
 	// cost calculates cost from a value
@@ -94,23 +94,15 @@ type Config struct {
 	Metrics bool
 	// OnEvict is called for every eviction and passes the hashed key, value,
 	// and cost to the function.
-	OnEvict func(key uint64, value interface{}, cost int64)
+	OnEvict func(key [2]uint64, value interface{}, cost int64)
 	// KeyToHash function is used to customize the key hashing algorithm.
 	// Each key will be hashed using the provided function. If keyToHash value
 	// is not set, the default keyToHash function is used.
-	KeyToHash func(key interface{}, seed uint8) uint64
+	KeyToHash func(key interface{}) [2]uint64
 	// Cost evaluates a value and outputs a corresponding cost. This function
 	// is ran after Set is called for a new item or an item update with a cost
 	// param of 0.
 	Cost func(value interface{}) int64
-	// Hashes is the number of 64-bit hashes to chain and use as each item's
-	// unique identifier. For example, setting Hashes to 2 will set internal
-	// keys to 128-bits and therefore very little probability of colliding with
-	// another key-value item in the cache. To just use 64-bit keys, set this
-	// value to 0 or 1.
-	//
-	// The larger this value is, the worse throughput performance will be.
-	Hashes uint8
 }
 
 type itemFlag byte
@@ -123,11 +115,11 @@ const (
 
 // item is passed to setBuf so items can eventually be added to the cache
 type item struct {
-	flag    itemFlag
-	key     interface{}
-	keyHash uint64
-	value   interface{}
-	cost    int64
+	flag   itemFlag
+	key    interface{}
+	hashes [2]uint64
+	value  interface{}
+	cost   int64
 }
 
 // NewCache returns a new Cache instance and any configuration errors, if any.
@@ -142,7 +134,7 @@ func NewCache(config *Config) (*Cache, error) {
 	}
 	policy := newPolicy(config.NumCounters, config.MaxCost)
 	cache := &Cache{
-		store:     newStore(config.Hashes),
+		store:     newStore(),
 		policy:    policy,
 		getBuf:    newRingBuffer(policy, config.BufferItems),
 		setBuf:    make(chan *item, setBufSize),
@@ -171,13 +163,13 @@ func (c *Cache) Get(key interface{}) (interface{}, bool) {
 	if c == nil || key == nil {
 		return nil, false
 	}
-	hashed := z.KeyToHash(key, 0)
-	c.getBuf.Push(hashed)
-	value, ok := c.store.Get(hashed, key)
+	hashes := z.KeyToHash(key)
+	c.getBuf.Push(hashes[0])
+	value, ok := c.store.Get(hashes)
 	if ok {
-		c.Metrics.add(hit, hashed, 1)
+		c.Metrics.add(hit, hashes[0], 1)
 	} else {
-		c.Metrics.add(miss, hashed, 1)
+		c.Metrics.add(miss, hashes[0], 1)
 	}
 	return value, ok
 }
@@ -196,15 +188,15 @@ func (c *Cache) Set(key, value interface{}, cost int64) bool {
 		return false
 	}
 	i := &item{
-		flag:    itemNew,
-		key:     key,
-		keyHash: z.KeyToHash(key, 0),
-		value:   value,
-		cost:    cost,
+		flag:   itemNew,
+		key:    key,
+		hashes: z.KeyToHash(key),
+		value:  value,
+		cost:   cost,
 	}
 	// attempt to immediately update hashmap value and set flag to update so the
 	// cost is eventually updated
-	if c.store.Update(i.keyHash, i.key, i.value) {
+	if c.store.Update(i.hashes, i.value) {
 		i.flag = itemUpdate
 	}
 	// attempt to send item to policy
@@ -212,7 +204,7 @@ func (c *Cache) Set(key, value interface{}, cost int64) bool {
 	case c.setBuf <- i:
 		return true
 	default:
-		c.Metrics.add(dropSets, i.keyHash, 1)
+		c.Metrics.add(dropSets, i.hashes[0], 1)
 		return false
 	}
 }
@@ -223,9 +215,9 @@ func (c *Cache) Del(key interface{}) {
 		return
 	}
 	c.setBuf <- &item{
-		flag:    itemDelete,
-		key:     key,
-		keyHash: z.KeyToHash(key, 0),
+		flag:   itemDelete,
+		key:    key,
+		hashes: z.KeyToHash(key),
 	}
 }
 
@@ -268,28 +260,28 @@ func (c *Cache) processItems() {
 			}
 			switch i.flag {
 			case itemNew:
-				if victims, added := c.policy.Add(i.keyHash, i.cost); added {
+				if victims, added := c.policy.Add(i.hashes[0], i.cost); added {
 					// item was accepted by the policy, so add to the hashmap
-					c.store.Set(i.keyHash, i.key, i.value)
+					c.store.Set(i.hashes, i.value)
 					// delete victims
 					for _, victim := range victims {
 						// TODO: make Get-Delete atomic
 						if c.onEvict != nil {
 							// force get with no collision checking because
 							// we don't have access to the victim's key
-							victim.value, _ = c.store.Get(victim.keyHash, nil)
-							c.onEvict(victim.keyHash, victim.value, victim.cost)
+							victim.value, _ = c.store.Get(victim.hashes)
+							c.onEvict(victim.hashes, victim.value, victim.cost)
 						}
 						// force delete with no collision checking because we
 						// don't have access to the original, unhashed key
-						c.store.Del(victim.keyHash, nil)
+						c.store.Del(victim.hashes)
 					}
 				}
 			case itemUpdate:
-				c.policy.Update(i.keyHash, i.cost)
+				c.policy.Update(i.hashes[0], i.cost)
 			case itemDelete:
-				c.policy.Del(i.keyHash)
-				c.store.Del(i.keyHash, i.key)
+				c.policy.Del(i.hashes[0])
+				c.store.Del(i.hashes)
 			}
 		case <-c.stop:
 			return

--- a/cache.go
+++ b/cache.go
@@ -116,7 +116,6 @@ const (
 // item is passed to setBuf so items can eventually be added to the cache
 type item struct {
 	flag   itemFlag
-	key    interface{}
 	hashes [2]uint64
 	value  interface{}
 	cost   int64
@@ -189,7 +188,6 @@ func (c *Cache) Set(key, value interface{}, cost int64) bool {
 	}
 	i := &item{
 		flag:   itemNew,
-		key:    key,
 		hashes: z.KeyToHash(key),
 		value:  value,
 		cost:   cost,
@@ -216,7 +214,6 @@ func (c *Cache) Del(key interface{}) {
 	}
 	c.setBuf <- &item{
 		flag:   itemDelete,
-		key:    key,
 		hashes: z.KeyToHash(key),
 	}
 }

--- a/cache.go
+++ b/cache.go
@@ -265,12 +265,16 @@ func (c *Cache) processItems() {
 				victims, added := c.policy.Add(i.key, i.cost)
 				if added {
 					c.store.Set(i.key, i.conflict, i.value)
+					c.Metrics.add(keyAdd, i.key, 1)
+					c.Metrics.add(costAdd, i.key, uint64(i.cost))
 				}
 				for _, victim := range victims {
 					victim.conflict, victim.value = c.store.Del(victim.key, 0)
 					if c.onEvict != nil {
 						c.onEvict(victim.key, victim.conflict, victim.value, victim.cost)
 					}
+					c.Metrics.add(keyEvict, victim.key, 1)
+					c.Metrics.add(costEvict, victim.key, uint64(victim.cost))
 				}
 			case itemUpdate:
 				c.policy.Update(i.key, i.cost)

--- a/cache.go
+++ b/cache.go
@@ -162,7 +162,7 @@ func (c *Cache) Get(key interface{}) (interface{}, bool) {
 	if c == nil || key == nil {
 		return nil, false
 	}
-	hashes := z.KeyToHash(key)
+	hashes := c.keyToHash(key)
 	c.getBuf.Push(hashes[0])
 	value, ok := c.store.Get(hashes)
 	if ok {
@@ -188,7 +188,7 @@ func (c *Cache) Set(key, value interface{}, cost int64) bool {
 	}
 	i := &item{
 		flag:   itemNew,
-		hashes: z.KeyToHash(key),
+		hashes: c.keyToHash(key),
 		value:  value,
 		cost:   cost,
 	}
@@ -214,7 +214,7 @@ func (c *Cache) Del(key interface{}) {
 	}
 	c.setBuf <- &item{
 		flag:   itemDelete,
-		hashes: z.KeyToHash(key),
+		hashes: c.keyToHash(key),
 	}
 }
 

--- a/cache.go
+++ b/cache.go
@@ -240,7 +240,7 @@ func (c *Cache) Clear() {
 	c.store.Clear()
 	// only reset metrics if they're enabled
 	if c.Metrics != nil {
-		c.collectMetrics()
+		c.Metrics.Clear()
 	}
 	// restart processItems goroutine
 	go c.processItems()
@@ -454,6 +454,17 @@ func (p *Metrics) Ratio() float64 {
 		return 0.0
 	}
 	return float64(hits) / float64(hits+misses)
+}
+
+func (p *Metrics) Clear() {
+	if p == nil {
+		return
+	}
+	for i := 0; i < doNotUse; i++ {
+		for j := range p.all[i] {
+			atomic.StoreUint64(p.all[i][j], 0)
+		}
+	}
 }
 
 func (p *Metrics) String() string {

--- a/cache_test.go
+++ b/cache_test.go
@@ -302,3 +302,32 @@ func TestMetricsString(t *testing.T) {
 		t.Fatal("stringFor() not handling doNotUse type")
 	}
 }
+
+func TestCacheMetricsClear(t *testing.T) {
+	c, err := NewCache(&Config{
+		NumCounters: 100,
+		MaxCost:     10,
+		BufferItems: 64,
+		Metrics:     true,
+	})
+	if err != nil {
+		panic(err)
+	}
+	c.Set(1, 1, 1)
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				c.Get(1)
+			}
+		}
+	}()
+	time.Sleep(wait)
+	c.Clear()
+	stop <- struct{}{}
+	c.Metrics = nil
+	c.Metrics.Clear()
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -61,7 +61,6 @@ func TestCacheProcessItems(t *testing.T) {
 
 	c.setBuf <- &item{
 		flag:   itemNew,
-		key:    1,
 		hashes: z.KeyToHash(1),
 		value:  1,
 		cost:   0,
@@ -72,7 +71,6 @@ func TestCacheProcessItems(t *testing.T) {
 	}
 	c.setBuf <- &item{
 		flag:   itemUpdate,
-		key:    1,
 		hashes: z.KeyToHash(1),
 		value:  2,
 		cost:   0,
@@ -83,7 +81,6 @@ func TestCacheProcessItems(t *testing.T) {
 	}
 	c.setBuf <- &item{
 		flag:   itemDelete,
-		key:    1,
 		hashes: z.KeyToHash(1),
 	}
 	time.Sleep(wait)
@@ -95,28 +92,24 @@ func TestCacheProcessItems(t *testing.T) {
 	}
 	c.setBuf <- &item{
 		flag:   itemNew,
-		key:    2,
 		hashes: z.KeyToHash(2),
 		value:  2,
 		cost:   3,
 	}
 	c.setBuf <- &item{
 		flag:   itemNew,
-		key:    3,
 		hashes: z.KeyToHash(3),
 		value:  3,
 		cost:   3,
 	}
 	c.setBuf <- &item{
 		flag:   itemNew,
-		key:    4,
 		hashes: z.KeyToHash(4),
 		value:  3,
 		cost:   3,
 	}
 	c.setBuf <- &item{
 		flag:   itemNew,
-		key:    5,
 		hashes: z.KeyToHash(5),
 		value:  3,
 		cost:   5,
@@ -193,7 +186,6 @@ func TestCacheSet(t *testing.T) {
 	for i := 0; i < setBufSize; i++ {
 		c.setBuf <- &item{
 			flag:   itemUpdate,
-			key:    1,
 			hashes: z.KeyToHash(1),
 			value:  1,
 			cost:   1,

--- a/cache_test.go
+++ b/cache_test.go
@@ -49,10 +49,10 @@ func TestCacheProcessItems(t *testing.T) {
 		Cost: func(value interface{}) int64 {
 			return int64(value.(int))
 		},
-		OnEvict: func(key uint64, value interface{}, cost int64) {
+		OnEvict: func(key [2]uint64, value interface{}, cost int64) {
 			m.Lock()
 			defer m.Unlock()
-			evicted[key] = struct{}{}
+			evicted[key[0]] = struct{}{}
 		},
 	})
 	if err != nil {
@@ -60,66 +60,66 @@ func TestCacheProcessItems(t *testing.T) {
 	}
 
 	c.setBuf <- &item{
-		flag:    itemNew,
-		key:     1,
-		keyHash: z.KeyToHash(1, 0),
-		value:   1,
-		cost:    0,
+		flag:   itemNew,
+		key:    1,
+		hashes: z.KeyToHash(1),
+		value:  1,
+		cost:   0,
 	}
 	time.Sleep(wait)
 	if !c.policy.Has(1) || c.policy.Cost(1) != 1 {
 		t.Fatal("cache processItems didn't add new item")
 	}
 	c.setBuf <- &item{
-		flag:    itemUpdate,
-		key:     1,
-		keyHash: z.KeyToHash(1, 0),
-		value:   2,
-		cost:    0,
+		flag:   itemUpdate,
+		key:    1,
+		hashes: z.KeyToHash(1),
+		value:  2,
+		cost:   0,
 	}
 	time.Sleep(wait)
 	if c.policy.Cost(1) != 2 {
 		t.Fatal("cache processItems didn't update item cost")
 	}
 	c.setBuf <- &item{
-		flag:    itemDelete,
-		key:     1,
-		keyHash: z.KeyToHash(1, 0),
+		flag:   itemDelete,
+		key:    1,
+		hashes: z.KeyToHash(1),
 	}
 	time.Sleep(wait)
-	if val, ok := c.store.Get(1, z.KeyToHash(1, 0)); val != nil || ok {
+	if val, ok := c.store.Get(z.KeyToHash(1)); val != nil || ok {
 		t.Fatal("cache processItems didn't delete item")
 	}
 	if c.policy.Has(1) {
 		t.Fatal("cache processItems didn't delete item")
 	}
 	c.setBuf <- &item{
-		flag:    itemNew,
-		key:     2,
-		keyHash: z.KeyToHash(2, 0),
-		value:   2,
-		cost:    3,
+		flag:   itemNew,
+		key:    2,
+		hashes: z.KeyToHash(2),
+		value:  2,
+		cost:   3,
 	}
 	c.setBuf <- &item{
-		flag:    itemNew,
-		key:     3,
-		keyHash: z.KeyToHash(3, 0),
-		value:   3,
-		cost:    3,
+		flag:   itemNew,
+		key:    3,
+		hashes: z.KeyToHash(3),
+		value:  3,
+		cost:   3,
 	}
 	c.setBuf <- &item{
-		flag:    itemNew,
-		key:     4,
-		keyHash: z.KeyToHash(4, 0),
-		value:   3,
-		cost:    3,
+		flag:   itemNew,
+		key:    4,
+		hashes: z.KeyToHash(4),
+		value:  3,
+		cost:   3,
 	}
 	c.setBuf <- &item{
-		flag:    itemNew,
-		key:     5,
-		keyHash: z.KeyToHash(5, 0),
-		value:   3,
-		cost:    5,
+		flag:   itemNew,
+		key:    5,
+		hashes: z.KeyToHash(5),
+		value:  3,
+		cost:   5,
 	}
 	time.Sleep(wait)
 	m.Lock()
@@ -147,7 +147,7 @@ func TestCacheGet(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	c.store.Set(1, z.KeyToHash(1, 0), 1)
+	c.store.Set(z.KeyToHash(1), 1)
 	if val, ok := c.Get(1); val == nil || !ok {
 		t.Fatal("get should be successful")
 	}
@@ -185,18 +185,18 @@ func TestCacheSet(t *testing.T) {
 		}
 	}
 	c.Set(1, 2, 2)
-	val, ok := c.store.Get(1, z.KeyToHash(1, 0))
+	val, ok := c.store.Get(z.KeyToHash(1))
 	if val == nil || val.(int) != 2 || !ok {
 		t.Fatal("set/update was unsuccessful")
 	}
 	c.stop <- struct{}{}
 	for i := 0; i < setBufSize; i++ {
 		c.setBuf <- &item{
-			flag:    itemUpdate,
-			key:     1,
-			keyHash: z.KeyToHash(1, 0),
-			value:   1,
-			cost:    1,
+			flag:   itemUpdate,
+			key:    1,
+			hashes: z.KeyToHash(1),
+			value:  1,
+			cost:   1,
 		}
 	}
 	if c.Set(2, 2, 1) {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/dgraph-io/ristretto
 
 go 1.12
 
-require github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
+require (
+	github.com/cespare/xxhash v1.1.0
+	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
+github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
+github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
+github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/policy.go
+++ b/policy.go
@@ -174,8 +174,9 @@ func (p *defaultPolicy) Add(key uint64, cost int64) ([]*item, bool) {
 		sample = sample[:len(sample)-1]
 		// store victim in evicted victims slice
 		victims = append(victims, &item{
-			hashes: [2]uint64{minKey, 0},
-			cost:   minCost,
+			key:      minKey,
+			conflict: 0,
+			cost:     minCost,
 		})
 	}
 	p.evict.add(key, cost)

--- a/policy.go
+++ b/policy.go
@@ -174,8 +174,8 @@ func (p *defaultPolicy) Add(key uint64, cost int64) ([]*item, bool) {
 		sample = sample[:len(sample)-1]
 		// store victim in evicted victims slice
 		victims = append(victims, &item{
-			key:  minKey,
-			cost: minCost,
+			keyHash: minKey,
+			cost:    minCost,
 		})
 	}
 	p.evict.add(key, cost)
@@ -210,18 +210,19 @@ func (p *defaultPolicy) Update(key uint64, cost int64) {
 
 func (p *defaultPolicy) Cost(key uint64) int64 {
 	p.Lock()
-	defer p.Unlock()
 	if cost, found := p.evict.keyCosts[key]; found {
+		p.Unlock()
 		return cost
 	}
+	p.Unlock()
 	return -1
 }
 
 func (p *defaultPolicy) Clear() {
 	p.Lock()
-	defer p.Unlock()
 	p.admit.clear()
 	p.evict.clear()
+	p.Unlock()
 }
 
 func (p *defaultPolicy) Close() {

--- a/policy.go
+++ b/policy.go
@@ -174,8 +174,8 @@ func (p *defaultPolicy) Add(key uint64, cost int64) ([]*item, bool) {
 		sample = sample[:len(sample)-1]
 		// store victim in evicted victims slice
 		victims = append(victims, &item{
-			keyHash: minKey,
-			cost:    minCost,
+			hashes: [2]uint64{minKey, 0},
+			cost:   minCost,
 		})
 	}
 	p.evict.add(key, cost)

--- a/store.go
+++ b/store.go
@@ -18,14 +18,11 @@ package ristretto
 
 import (
 	"sync"
-
-	"github.com/dgraph-io/ristretto/z"
 )
 
 type storeItem struct {
-	keyHash uint64
-	hashes  []uint64
-	value   interface{}
+	hashes [2]uint64
+	value  interface{}
 }
 
 // store is the interface fulfilled by all hash map implementations in this
@@ -36,22 +33,22 @@ type storeItem struct {
 // Every store is safe for concurrent usage.
 type store interface {
 	// Get returns the value associated with the key parameter.
-	Get(uint64, interface{}) (interface{}, bool)
+	Get([2]uint64) (interface{}, bool)
 	// Set adds the key-value pair to the Map or updates the value if it's
 	// already present.
-	Set(uint64, interface{}, interface{})
+	Set([2]uint64, interface{})
 	// Del deletes the key-value pair from the Map.
-	Del(uint64, interface{})
+	Del([2]uint64)
 	// Update attempts to update the key with a new value and returns true if
 	// successful.
-	Update(uint64, interface{}, interface{}) bool
+	Update([2]uint64, interface{}) bool
 	// Clear clears all contents of the store.
 	Clear()
 }
 
 // newStore returns the default store implementation.
-func newStore(rounds uint8) store {
-	return newShardedMap(rounds)
+func newStore() store {
+	return newShardedMap()
 }
 
 const numShards uint64 = 256
@@ -60,30 +57,30 @@ type shardedMap struct {
 	shards []*lockedMap
 }
 
-func newShardedMap(rounds uint8) *shardedMap {
+func newShardedMap() *shardedMap {
 	sm := &shardedMap{
 		shards: make([]*lockedMap, int(numShards)),
 	}
 	for i := range sm.shards {
-		sm.shards[i] = newLockedMap(rounds)
+		sm.shards[i] = newLockedMap()
 	}
 	return sm
 }
 
-func (sm *shardedMap) Get(hashed uint64, key interface{}) (interface{}, bool) {
-	return sm.shards[hashed%numShards].Get(hashed, key)
+func (sm *shardedMap) Get(hashes [2]uint64) (interface{}, bool) {
+	return sm.shards[hashes[0]%numShards].Get(hashes)
 }
 
-func (sm *shardedMap) Set(hashed uint64, key, value interface{}) {
-	sm.shards[hashed%numShards].Set(hashed, key, value)
+func (sm *shardedMap) Set(hashes [2]uint64, value interface{}) {
+	sm.shards[hashes[0]%numShards].Set(hashes, value)
 }
 
-func (sm *shardedMap) Del(hashed uint64, key interface{}) {
-	sm.shards[hashed%numShards].Del(hashed, key)
+func (sm *shardedMap) Del(hashes [2]uint64) {
+	sm.shards[hashes[0]%numShards].Del(hashes)
 }
 
-func (sm *shardedMap) Update(hashed uint64, key, value interface{}) bool {
-	return sm.shards[hashed%numShards].Update(hashed, key, value)
+func (sm *shardedMap) Update(hashes [2]uint64, value interface{}) bool {
+	return sm.shards[hashes[0]%numShards].Update(hashes, value)
 }
 
 func (sm *shardedMap) Clear() {
@@ -94,104 +91,79 @@ func (sm *shardedMap) Clear() {
 
 type lockedMap struct {
 	sync.RWMutex
-	data   map[uint64]storeItem
-	rounds uint8
+	data map[uint64]storeItem
 }
 
-func newLockedMap(rounds uint8) *lockedMap {
+func newLockedMap() *lockedMap {
 	return &lockedMap{
-		data:   make(map[uint64]storeItem),
-		rounds: rounds,
+		data: make(map[uint64]storeItem),
 	}
 }
 
-func (m *lockedMap) Get(keyHash uint64, key interface{}) (interface{}, bool) {
+func (m *lockedMap) Get(hashes [2]uint64) (interface{}, bool) {
 	m.RLock()
-	item, ok := m.data[keyHash]
+	item, ok := m.data[hashes[0]]
 	m.RUnlock()
 	if !ok {
 		return nil, false
 	}
-	if key != nil {
-		for i := uint8(1); i < m.rounds; i++ {
-			if z.KeyToHash(key, i) != item.hashes[i-1] {
-				return nil, false
-			}
-		}
+	if (item.hashes[1] != hashes[1]) && hashes[1] != 0 {
+		return nil, false
 	}
 	return item.value, true
 }
 
-func (m *lockedMap) Set(keyHash uint64, key, value interface{}) {
+func (m *lockedMap) Set(hashes [2]uint64, value interface{}) {
 	m.Lock()
-	item, ok := m.data[keyHash]
+	item, ok := m.data[hashes[0]]
 	if !ok {
-		hashes := make([]uint64, m.rounds)
-		for i := uint8(1); i < m.rounds; i++ {
-			hashes[i-1] = z.KeyToHash(key, i)
-		}
-		m.data[keyHash] = storeItem{
-			keyHash: keyHash,
-			hashes:  hashes,
-			value:   value,
+		m.data[hashes[0]] = storeItem{
+			hashes: hashes,
+			value:  value,
 		}
 		m.Unlock()
 		return
 	}
-	if key != nil {
-		for i := uint8(1); i < m.rounds; i++ {
-			if z.KeyToHash(key, i) != item.hashes[i-1] {
-				m.Unlock()
-				return
-			}
-		}
+	if (item.hashes[1] != hashes[1]) && hashes[1] != 0 {
+		m.Unlock()
+		return
 	}
-	m.data[keyHash] = storeItem{
-		keyHash: keyHash,
-		hashes:  item.hashes,
-		value:   value,
+	m.data[hashes[0]] = storeItem{
+		hashes: item.hashes,
+		value:  value,
 	}
 	m.Unlock()
 }
 
-func (m *lockedMap) Del(keyHash uint64, key interface{}) {
+func (m *lockedMap) Del(hashes [2]uint64) {
 	m.Lock()
-	item, ok := m.data[keyHash]
+	item, ok := m.data[hashes[0]]
 	if !ok {
 		m.Unlock()
 		return
 	}
-	if key != nil {
-		for i := uint8(1); i < m.rounds; i++ {
-			if z.KeyToHash(key, i) != item.hashes[i-1] {
-				m.Unlock()
-				return
-			}
-		}
+	if (item.hashes[1] != hashes[1]) && hashes[1] != 0 {
+		m.Unlock()
+		return
 	}
-	delete(m.data, keyHash)
+	delete(m.data, hashes[0])
 	m.Unlock()
 }
 
-func (m *lockedMap) Update(keyHash uint64, key, value interface{}) bool {
+func (m *lockedMap) Update(hashes [2]uint64, value interface{}) bool {
 	m.Lock()
-	item, ok := m.data[keyHash]
+	item, ok := m.data[hashes[0]]
 	if !ok {
 		m.Unlock()
 		return false
 	}
-	if key != nil {
-		for i := uint8(1); i < m.rounds; i++ {
-			if z.KeyToHash(key, i) != item.hashes[i-1] {
-				m.Unlock()
-				return false
-			}
-		}
+	if (item.hashes[1] != hashes[1]) && hashes[1] != 0 {
+		m.Unlock()
+		return false
 	}
-	m.data[keyHash] = storeItem{
-		keyHash: keyHash,
-		hashes:  item.hashes,
-		value:   value,
+	m.data[hashes[0]] = storeItem{
+		hashes: item.hashes,
+		value:  value,
 	}
 	m.Unlock()
 	return true

--- a/store.go
+++ b/store.go
@@ -18,7 +18,15 @@ package ristretto
 
 import (
 	"sync"
+
+	"github.com/dgraph-io/ristretto/z"
 )
+
+type storeItem struct {
+	keyHash uint64
+	hashes  []uint64
+	value   interface{}
+}
 
 // store is the interface fulfilled by all hash map implementations in this
 // file. Some hash map implementations are better suited for certain data
@@ -28,22 +36,22 @@ import (
 // Every store is safe for concurrent usage.
 type store interface {
 	// Get returns the value associated with the key parameter.
-	Get(uint64) (interface{}, bool)
+	Get(uint64, interface{}) (interface{}, bool)
 	// Set adds the key-value pair to the Map or updates the value if it's
 	// already present.
-	Set(uint64, interface{})
+	Set(uint64, interface{}, interface{})
 	// Del deletes the key-value pair from the Map.
-	Del(uint64)
-	// Clear clears all contents of the store.
-	Clear()
+	Del(uint64, interface{})
 	// Update attempts to update the key with a new value and returns true if
 	// successful.
-	Update(uint64, interface{}) bool
+	Update(uint64, interface{}, interface{}) bool
+	// Clear clears all contents of the store.
+	Clear()
 }
 
 // newStore returns the default store implementation.
-func newStore() store {
-	return newShardedMap()
+func newStore(rounds uint8) store {
+	return newShardedMap(rounds)
 }
 
 const numShards uint64 = 256
@@ -52,27 +60,30 @@ type shardedMap struct {
 	shards []*lockedMap
 }
 
-func newShardedMap() *shardedMap {
-	sm := &shardedMap{shards: make([]*lockedMap, int(numShards))}
+func newShardedMap(rounds uint8) *shardedMap {
+	sm := &shardedMap{
+		shards: make([]*lockedMap, int(numShards)),
+	}
 	for i := range sm.shards {
-		sm.shards[i] = newLockedMap()
+		sm.shards[i] = newLockedMap(rounds)
 	}
 	return sm
 }
 
-func (sm *shardedMap) Get(key uint64) (interface{}, bool) {
-	idx := key % numShards
-	return sm.shards[idx].Get(key)
+func (sm *shardedMap) Get(hashed uint64, key interface{}) (interface{}, bool) {
+	return sm.shards[hashed%numShards].Get(hashed, key)
 }
 
-func (sm *shardedMap) Set(key uint64, value interface{}) {
-	idx := key % numShards
-	sm.shards[idx].Set(key, value)
+func (sm *shardedMap) Set(hashed uint64, key, value interface{}) {
+	sm.shards[hashed%numShards].Set(hashed, key, value)
 }
 
-func (sm *shardedMap) Del(key uint64) {
-	idx := key % numShards
-	sm.shards[idx].Del(key)
+func (sm *shardedMap) Del(hashed uint64, key interface{}) {
+	sm.shards[hashed%numShards].Del(hashed, key)
+}
+
+func (sm *shardedMap) Update(hashed uint64, key, value interface{}) bool {
+	return sm.shards[hashed%numShards].Update(hashed, key, value)
 }
 
 func (sm *shardedMap) Clear() {
@@ -81,51 +92,113 @@ func (sm *shardedMap) Clear() {
 	}
 }
 
-func (sm *shardedMap) Update(key uint64, value interface{}) bool {
-	idx := key % numShards
-	return sm.shards[idx].Update(key, value)
-}
-
 type lockedMap struct {
 	sync.RWMutex
-	data map[uint64]interface{}
+	data   map[uint64]storeItem
+	rounds uint8
 }
 
-func newLockedMap() *lockedMap {
-	return &lockedMap{data: make(map[uint64]interface{})}
-}
-
-func (m *lockedMap) Get(key uint64) (interface{}, bool) {
-	m.RLock()
-	val, found := m.data[key]
-	m.RUnlock()
-	return val, found
-}
-
-func (m *lockedMap) Set(key uint64, value interface{}) {
-	m.Lock()
-	m.data[key] = value
-	m.Unlock()
-}
-
-func (m *lockedMap) Del(key uint64) {
-	m.Lock()
-	delete(m.data, key)
-	m.Unlock()
-}
-
-func (m *lockedMap) Update(key uint64, value interface{}) bool {
-	m.Lock()
-	defer m.Unlock()
-	if _, found := m.data[key]; found {
-		m.data[key] = value
-		return true
+func newLockedMap(rounds uint8) *lockedMap {
+	return &lockedMap{
+		data:   make(map[uint64]storeItem),
+		rounds: rounds,
 	}
-	return false
+}
+
+func (m *lockedMap) Get(keyHash uint64, key interface{}) (interface{}, bool) {
+	m.RLock()
+	item, ok := m.data[keyHash]
+	m.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if key != nil {
+		for i := uint8(1); i < m.rounds; i++ {
+			if z.KeyToHash(key, i) != item.hashes[i-1] {
+				return nil, false
+			}
+		}
+	}
+	return item.value, true
+}
+
+func (m *lockedMap) Set(keyHash uint64, key, value interface{}) {
+	m.Lock()
+	item, ok := m.data[keyHash]
+	if !ok {
+		hashes := make([]uint64, m.rounds)
+		for i := uint8(1); i < m.rounds; i++ {
+			hashes[i-1] = z.KeyToHash(key, i)
+		}
+		m.data[keyHash] = storeItem{
+			keyHash: keyHash,
+			hashes:  hashes,
+			value:   value,
+		}
+		m.Unlock()
+		return
+	}
+	if key != nil {
+		for i := uint8(1); i < m.rounds; i++ {
+			if z.KeyToHash(key, i) != item.hashes[i-1] {
+				m.Unlock()
+				return
+			}
+		}
+	}
+	m.data[keyHash] = storeItem{
+		keyHash: keyHash,
+		hashes:  item.hashes,
+		value:   value,
+	}
+	m.Unlock()
+}
+
+func (m *lockedMap) Del(keyHash uint64, key interface{}) {
+	m.Lock()
+	item, ok := m.data[keyHash]
+	if !ok {
+		m.Unlock()
+		return
+	}
+	if key != nil {
+		for i := uint8(1); i < m.rounds; i++ {
+			if z.KeyToHash(key, i) != item.hashes[i-1] {
+				m.Unlock()
+				return
+			}
+		}
+	}
+	delete(m.data, keyHash)
+	m.Unlock()
+}
+
+func (m *lockedMap) Update(keyHash uint64, key, value interface{}) bool {
+	m.Lock()
+	item, ok := m.data[keyHash]
+	if !ok {
+		m.Unlock()
+		return false
+	}
+	if key != nil {
+		for i := uint8(1); i < m.rounds; i++ {
+			if z.KeyToHash(key, i) != item.hashes[i-1] {
+				m.Unlock()
+				return false
+			}
+		}
+	}
+	m.data[keyHash] = storeItem{
+		keyHash: keyHash,
+		hashes:  item.hashes,
+		value:   value,
+	}
+	m.Unlock()
+	return true
 }
 
 func (m *lockedMap) Clear() {
 	m.Lock()
-	defer m.Unlock()
-	m.data = make(map[uint64]interface{})
+	m.data = make(map[uint64]storeItem)
+	m.Unlock()
 }

--- a/store_test.go
+++ b/store_test.go
@@ -1,89 +1,139 @@
 package ristretto
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/dgraph-io/ristretto/z"
+)
 
 func TestStoreSetGet(t *testing.T) {
-	s := newStore()
-	s.Set(1, 2)
-	if val, ok := s.Get(1); (val == nil || !ok) || val.(int) != 2 {
+	s := newStore(2)
+	hashed := z.KeyToHash(1, 0)
+	s.Set(hashed, 1, 2)
+	if val, ok := s.Get(hashed, 1); (val == nil || !ok) || val.(int) != 2 {
 		t.Fatal("set/get error")
 	}
-	s.Set(1, 3)
-	if val, ok := s.Get(1); (val == nil || !ok) || val.(int) != 3 {
+	s.Set(hashed, 1, 3)
+	if val, ok := s.Get(hashed, 1); (val == nil || !ok) || val.(int) != 3 {
 		t.Fatal("set/get overwrite error")
+	}
+	s.Set(z.KeyToHash(2, 0), nil, 2)
+	if val, ok := s.Get(z.KeyToHash(2, 0), nil); !ok || val.(int) != 2 {
+		t.Fatal("set/get nil key error")
 	}
 }
 
 func TestStoreDel(t *testing.T) {
-	s := newStore()
-	s.Set(1, 1)
-	s.Del(1)
-	if val, ok := s.Get(1); val != nil || ok {
+	s := newStore(2)
+	hashed := z.KeyToHash(1, 0)
+	s.Set(hashed, 1, 1)
+	s.Del(hashed, 1)
+	if val, ok := s.Get(hashed, 1); val != nil || ok {
 		t.Fatal("del error")
 	}
+	s.Del(2, 2)
 }
 
 func TestStoreClear(t *testing.T) {
-	s := newStore()
+	s := newStore(2)
 	for i := uint64(0); i < 1000; i++ {
-		s.Set(i, i)
+		s.Set(z.KeyToHash(i, 0), i, i)
 	}
 	s.Clear()
 	for i := uint64(0); i < 1000; i++ {
-		if val, ok := s.Get(i); val != nil || ok {
+		if val, ok := s.Get(z.KeyToHash(i, 0), i); val != nil || ok {
 			t.Fatal("clear operation failed")
 		}
 	}
 }
 
 func TestStoreUpdate(t *testing.T) {
-	s := newStore()
-	s.Set(1, 1)
-	if updated := s.Update(1, 2); !updated {
+	s := newStore(2)
+	hashedOne := z.KeyToHash(1, 0)
+	s.Set(hashedOne, 1, 1)
+	if updated := s.Update(hashedOne, 1, 2); !updated {
 		t.Fatal("value should have been updated")
 	}
-	if val, ok := s.Get(1); val == nil || !ok {
+	if val, ok := s.Get(hashedOne, 1); val == nil || !ok {
 		t.Fatal("value was deleted")
 	}
-	if val, ok := s.Get(1); val.(int) != 2 || !ok {
+	if val, ok := s.Get(hashedOne, 1); val.(int) != 2 || !ok {
 		t.Fatal("value wasn't updated")
 	}
-	if updated := s.Update(2, 2); updated {
+	if !s.Update(hashedOne, nil, 3) {
+		t.Fatal("value should have been updated")
+	}
+	if val, ok := s.Get(hashedOne, 1); val.(int) != 3 || !ok {
+		t.Fatal("value wasn't updated")
+	}
+	hashedTwo := z.KeyToHash(2, 0)
+	if updated := s.Update(hashedTwo, 2, 2); updated {
 		t.Fatal("value should not have been updated")
 	}
-	if val, ok := s.Get(2); val != nil || ok {
+	if val, ok := s.Get(hashedTwo, 2); val != nil || ok {
 		t.Fatal("value should not have been updated")
 	}
 }
 
+func TestStoreCollision(t *testing.T) {
+	s := newShardedMap(2)
+	s.shards[1].Lock()
+	s.shards[1].data[1] = storeItem{
+		keyHash: 1,
+		hashes:  []uint64{2},
+		value:   1,
+	}
+	s.shards[1].Unlock()
+	if val, ok := s.Get(1, 1); val != nil || ok {
+		t.Fatal("collision should return nil")
+	}
+	s.Set(1, 1, 2)
+	if val, ok := s.Get(1, 2); !ok || val == nil || val.(int) == 2 {
+		t.Fatal("collision should prevent Set update")
+	}
+	if s.Update(1, 1, 2) {
+		t.Fatal("collision should prevent Update")
+	}
+	if val, ok := s.Get(1, 2); !ok || val == nil || val.(int) == 2 {
+		t.Fatal("collision should prevent Update")
+	}
+	s.Del(1, 1)
+	if val, ok := s.Get(1, 2); !ok || val == nil {
+		t.Fatal("collision should prevent Del")
+	}
+}
+
 func BenchmarkStoreGet(b *testing.B) {
-	s := newStore()
-	s.Set(1, 1)
+	s := newStore(2)
+	hashed := z.KeyToHash(1, 0)
+	s.Set(hashed, 1, 1)
 	b.SetBytes(1)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			s.Get(1)
+			s.Get(hashed, 1)
 		}
 	})
 }
 
 func BenchmarkStoreSet(b *testing.B) {
-	s := newStore()
+	s := newStore(2)
+	hashed := z.KeyToHash(1, 0)
 	b.SetBytes(1)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			s.Set(1, 1)
+			s.Set(hashed, 1, 1)
 		}
 	})
 }
 
 func BenchmarkStoreUpdate(b *testing.B) {
-	s := newStore()
-	s.Set(1, 1)
+	s := newStore(2)
+	hashed := z.KeyToHash(1, 0)
+	s.Set(hashed, 1, 1)
 	b.SetBytes(1)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			s.Update(1, 2)
+			s.Update(hashed, 1, 2)
 		}
 	})
 }

--- a/store_test.go
+++ b/store_test.go
@@ -8,40 +8,43 @@ import (
 
 func TestStoreSetGet(t *testing.T) {
 	s := newStore()
-	hashes := z.KeyToHash(1)
-	s.Set(hashes, 2)
-	if val, ok := s.Get(hashes); (val == nil || !ok) || val.(int) != 2 {
+	key, conflict := z.KeyToHash(1)
+	s.Set(key, conflict, 2)
+	if val, ok := s.Get(key, conflict); (val == nil || !ok) || val.(int) != 2 {
 		t.Fatal("set/get error")
 	}
-	s.Set(hashes, 3)
-	if val, ok := s.Get(hashes); (val == nil || !ok) || val.(int) != 3 {
+	s.Set(key, conflict, 3)
+	if val, ok := s.Get(key, conflict); (val == nil || !ok) || val.(int) != 3 {
 		t.Fatal("set/get overwrite error")
 	}
-	s.Set(z.KeyToHash(2), 2)
-	if val, ok := s.Get(z.KeyToHash(2)); !ok || val.(int) != 2 {
+	key, conflict = z.KeyToHash(2)
+	s.Set(key, conflict, 2)
+	if val, ok := s.Get(key, conflict); !ok || val.(int) != 2 {
 		t.Fatal("set/get nil key error")
 	}
 }
 
 func TestStoreDel(t *testing.T) {
 	s := newStore()
-	hashes := z.KeyToHash(1)
-	s.Set(hashes, 1)
-	s.Del(hashes)
-	if val, ok := s.Get(hashes); val != nil || ok {
+	key, conflict := z.KeyToHash(1)
+	s.Set(key, conflict, 1)
+	s.Del(key, conflict)
+	if val, ok := s.Get(key, conflict); val != nil || ok {
 		t.Fatal("del error")
 	}
-	s.Del([2]uint64{2, 0})
+	s.Del(2, 0)
 }
 
 func TestStoreClear(t *testing.T) {
 	s := newStore()
 	for i := uint64(0); i < 1000; i++ {
-		s.Set(z.KeyToHash(i), i)
+		key, conflict := z.KeyToHash(i)
+		s.Set(key, conflict, i)
 	}
 	s.Clear()
 	for i := uint64(0); i < 1000; i++ {
-		if val, ok := s.Get(z.KeyToHash(i)); val != nil || ok {
+		key, conflict := z.KeyToHash(i)
+		if val, ok := s.Get(key, conflict); val != nil || ok {
 			t.Fatal("clear operation failed")
 		}
 	}
@@ -49,28 +52,28 @@ func TestStoreClear(t *testing.T) {
 
 func TestStoreUpdate(t *testing.T) {
 	s := newStore()
-	hashedOne := z.KeyToHash(1)
-	s.Set(hashedOne, 1)
-	if updated := s.Update(hashedOne, 2); !updated {
+	key, conflict := z.KeyToHash(1)
+	s.Set(key, conflict, 1)
+	if updated := s.Update(key, conflict, 2); !updated {
 		t.Fatal("value should have been updated")
 	}
-	if val, ok := s.Get(hashedOne); val == nil || !ok {
+	if val, ok := s.Get(key, conflict); val == nil || !ok {
 		t.Fatal("value was deleted")
 	}
-	if val, ok := s.Get(hashedOne); val.(int) != 2 || !ok {
+	if val, ok := s.Get(key, conflict); val.(int) != 2 || !ok {
 		t.Fatal("value wasn't updated")
 	}
-	if !s.Update(hashedOne, 3) {
+	if !s.Update(key, conflict, 3) {
 		t.Fatal("value should have been updated")
 	}
-	if val, ok := s.Get(hashedOne); val.(int) != 3 || !ok {
+	if val, ok := s.Get(key, conflict); val.(int) != 3 || !ok {
 		t.Fatal("value wasn't updated")
 	}
-	hashedTwo := z.KeyToHash(2)
-	if updated := s.Update(hashedTwo, 2); updated {
+	key, conflict = z.KeyToHash(2)
+	if updated := s.Update(key, conflict, 2); updated {
 		t.Fatal("value should not have been updated")
 	}
-	if val, ok := s.Get(hashedTwo); val != nil || ok {
+	if val, ok := s.Get(key, conflict); val != nil || ok {
 		t.Fatal("value should not have been updated")
 	}
 }
@@ -79,60 +82,61 @@ func TestStoreCollision(t *testing.T) {
 	s := newShardedMap()
 	s.shards[1].Lock()
 	s.shards[1].data[1] = storeItem{
-		hashes: [2]uint64{1, 0},
-		value:  1,
+		key:      1,
+		conflict: 0,
+		value:    1,
 	}
 	s.shards[1].Unlock()
-	if val, ok := s.Get([2]uint64{1, 1}); val != nil || ok {
+	if val, ok := s.Get(1, 1); val != nil || ok {
 		t.Fatal("collision should return nil")
 	}
-	s.Set([2]uint64{1, 1}, 2)
-	if val, ok := s.Get([2]uint64{1, 0}); !ok || val == nil || val.(int) == 2 {
+	s.Set(1, 1, 2)
+	if val, ok := s.Get(1, 0); !ok || val == nil || val.(int) == 2 {
 		t.Fatal("collision should prevent Set update")
 	}
-	if s.Update([2]uint64{1, 1}, 2) {
+	if s.Update(1, 1, 2) {
 		t.Fatal("collision should prevent Update")
 	}
-	if val, ok := s.Get([2]uint64{1, 0}); !ok || val == nil || val.(int) == 2 {
+	if val, ok := s.Get(1, 0); !ok || val == nil || val.(int) == 2 {
 		t.Fatal("collision should prevent Update")
 	}
-	s.Del([2]uint64{1, 1})
-	if val, ok := s.Get([2]uint64{1, 0}); !ok || val == nil {
+	s.Del(1, 1)
+	if val, ok := s.Get(1, 0); !ok || val == nil {
 		t.Fatal("collision should prevent Del")
 	}
 }
 
 func BenchmarkStoreGet(b *testing.B) {
 	s := newStore()
-	hashes := z.KeyToHash(1)
-	s.Set(hashes, 1)
+	key, conflict := z.KeyToHash(1)
+	s.Set(key, conflict, 1)
 	b.SetBytes(1)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			s.Get(hashes)
+			s.Get(key, conflict)
 		}
 	})
 }
 
 func BenchmarkStoreSet(b *testing.B) {
 	s := newStore()
-	hashes := z.KeyToHash(1)
+	key, conflict := z.KeyToHash(1)
 	b.SetBytes(1)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			s.Set(hashes, 1)
+			s.Set(key, conflict, 1)
 		}
 	})
 }
 
 func BenchmarkStoreUpdate(b *testing.B) {
 	s := newStore()
-	hashes := z.KeyToHash(1)
-	s.Set(hashes, 1)
+	key, conflict := z.KeyToHash(1)
+	s.Set(key, conflict, 1)
 	b.SetBytes(1)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			s.Update(hashes, 2)
+			s.Update(key, conflict, 2)
 		}
 	})
 }

--- a/store_test.go
+++ b/store_test.go
@@ -7,133 +7,132 @@ import (
 )
 
 func TestStoreSetGet(t *testing.T) {
-	s := newStore(2)
-	hashed := z.KeyToHash(1, 0)
-	s.Set(hashed, 1, 2)
-	if val, ok := s.Get(hashed, 1); (val == nil || !ok) || val.(int) != 2 {
+	s := newStore()
+	hashes := z.KeyToHash(1)
+	s.Set(hashes, 2)
+	if val, ok := s.Get(hashes); (val == nil || !ok) || val.(int) != 2 {
 		t.Fatal("set/get error")
 	}
-	s.Set(hashed, 1, 3)
-	if val, ok := s.Get(hashed, 1); (val == nil || !ok) || val.(int) != 3 {
+	s.Set(hashes, 3)
+	if val, ok := s.Get(hashes); (val == nil || !ok) || val.(int) != 3 {
 		t.Fatal("set/get overwrite error")
 	}
-	s.Set(z.KeyToHash(2, 0), nil, 2)
-	if val, ok := s.Get(z.KeyToHash(2, 0), nil); !ok || val.(int) != 2 {
+	s.Set(z.KeyToHash(2), 2)
+	if val, ok := s.Get(z.KeyToHash(2)); !ok || val.(int) != 2 {
 		t.Fatal("set/get nil key error")
 	}
 }
 
 func TestStoreDel(t *testing.T) {
-	s := newStore(2)
-	hashed := z.KeyToHash(1, 0)
-	s.Set(hashed, 1, 1)
-	s.Del(hashed, 1)
-	if val, ok := s.Get(hashed, 1); val != nil || ok {
+	s := newStore()
+	hashes := z.KeyToHash(1)
+	s.Set(hashes, 1)
+	s.Del(hashes)
+	if val, ok := s.Get(hashes); val != nil || ok {
 		t.Fatal("del error")
 	}
-	s.Del(2, 2)
+	s.Del([2]uint64{2, 0})
 }
 
 func TestStoreClear(t *testing.T) {
-	s := newStore(2)
+	s := newStore()
 	for i := uint64(0); i < 1000; i++ {
-		s.Set(z.KeyToHash(i, 0), i, i)
+		s.Set(z.KeyToHash(i), i)
 	}
 	s.Clear()
 	for i := uint64(0); i < 1000; i++ {
-		if val, ok := s.Get(z.KeyToHash(i, 0), i); val != nil || ok {
+		if val, ok := s.Get(z.KeyToHash(i)); val != nil || ok {
 			t.Fatal("clear operation failed")
 		}
 	}
 }
 
 func TestStoreUpdate(t *testing.T) {
-	s := newStore(2)
-	hashedOne := z.KeyToHash(1, 0)
-	s.Set(hashedOne, 1, 1)
-	if updated := s.Update(hashedOne, 1, 2); !updated {
+	s := newStore()
+	hashedOne := z.KeyToHash(1)
+	s.Set(hashedOne, 1)
+	if updated := s.Update(hashedOne, 2); !updated {
 		t.Fatal("value should have been updated")
 	}
-	if val, ok := s.Get(hashedOne, 1); val == nil || !ok {
+	if val, ok := s.Get(hashedOne); val == nil || !ok {
 		t.Fatal("value was deleted")
 	}
-	if val, ok := s.Get(hashedOne, 1); val.(int) != 2 || !ok {
+	if val, ok := s.Get(hashedOne); val.(int) != 2 || !ok {
 		t.Fatal("value wasn't updated")
 	}
-	if !s.Update(hashedOne, nil, 3) {
+	if !s.Update(hashedOne, 3) {
 		t.Fatal("value should have been updated")
 	}
-	if val, ok := s.Get(hashedOne, 1); val.(int) != 3 || !ok {
+	if val, ok := s.Get(hashedOne); val.(int) != 3 || !ok {
 		t.Fatal("value wasn't updated")
 	}
-	hashedTwo := z.KeyToHash(2, 0)
-	if updated := s.Update(hashedTwo, 2, 2); updated {
+	hashedTwo := z.KeyToHash(2)
+	if updated := s.Update(hashedTwo, 2); updated {
 		t.Fatal("value should not have been updated")
 	}
-	if val, ok := s.Get(hashedTwo, 2); val != nil || ok {
+	if val, ok := s.Get(hashedTwo); val != nil || ok {
 		t.Fatal("value should not have been updated")
 	}
 }
 
 func TestStoreCollision(t *testing.T) {
-	s := newShardedMap(2)
+	s := newShardedMap()
 	s.shards[1].Lock()
 	s.shards[1].data[1] = storeItem{
-		keyHash: 1,
-		hashes:  []uint64{2},
-		value:   1,
+		hashes: [2]uint64{1, 0},
+		value:  1,
 	}
 	s.shards[1].Unlock()
-	if val, ok := s.Get(1, 1); val != nil || ok {
+	if val, ok := s.Get([2]uint64{1, 1}); val != nil || ok {
 		t.Fatal("collision should return nil")
 	}
-	s.Set(1, 1, 2)
-	if val, ok := s.Get(1, 2); !ok || val == nil || val.(int) == 2 {
+	s.Set([2]uint64{1, 1}, 2)
+	if val, ok := s.Get([2]uint64{1, 0}); !ok || val == nil || val.(int) == 2 {
 		t.Fatal("collision should prevent Set update")
 	}
-	if s.Update(1, 1, 2) {
+	if s.Update([2]uint64{1, 1}, 2) {
 		t.Fatal("collision should prevent Update")
 	}
-	if val, ok := s.Get(1, 2); !ok || val == nil || val.(int) == 2 {
+	if val, ok := s.Get([2]uint64{1, 0}); !ok || val == nil || val.(int) == 2 {
 		t.Fatal("collision should prevent Update")
 	}
-	s.Del(1, 1)
-	if val, ok := s.Get(1, 2); !ok || val == nil {
+	s.Del([2]uint64{1, 1})
+	if val, ok := s.Get([2]uint64{1, 0}); !ok || val == nil {
 		t.Fatal("collision should prevent Del")
 	}
 }
 
 func BenchmarkStoreGet(b *testing.B) {
-	s := newStore(2)
-	hashed := z.KeyToHash(1, 0)
-	s.Set(hashed, 1, 1)
+	s := newStore()
+	hashes := z.KeyToHash(1)
+	s.Set(hashes, 1)
 	b.SetBytes(1)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			s.Get(hashed, 1)
+			s.Get(hashes)
 		}
 	})
 }
 
 func BenchmarkStoreSet(b *testing.B) {
-	s := newStore(2)
-	hashed := z.KeyToHash(1, 0)
+	s := newStore()
+	hashes := z.KeyToHash(1)
 	b.SetBytes(1)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			s.Set(hashed, 1, 1)
+			s.Set(hashes, 1)
 		}
 	})
 }
 
 func BenchmarkStoreUpdate(b *testing.B) {
-	s := newStore(2)
-	hashed := z.KeyToHash(1, 0)
-	s.Set(hashed, 1, 1)
+	s := newStore()
+	hashes := z.KeyToHash(1)
+	s.Set(hashes, 1)
 	b.SetBytes(1)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			s.Update(hashed, 1, 2)
+			s.Update(hashes, 2)
 		}
 	})
 }

--- a/z/z.go
+++ b/z/z.go
@@ -16,28 +16,32 @@
 
 package z
 
-// KeyToHash interprets the type of key and converts it to a uint64 hash.
-func KeyToHash(key interface{}, seed uint8) uint64 {
+import (
+	"github.com/cespare/xxhash"
+)
+
+func KeyToHash(key interface{}) [2]uint64 {
 	if key == nil {
-		return 0 + uint64(seed)
+		return [2]uint64{0, 0}
 	}
 	switch k := key.(type) {
 	case uint64:
-		return k
+		return [2]uint64{k, 0}
 	case string:
-		return MemHash(append([]byte(k), seed))
+		raw := []byte(k)
+		return [2]uint64{MemHash(raw), xxhash.Sum64(raw)}
 	case []byte:
-		return MemHash(append(k, seed))
+		return [2]uint64{MemHash(k), xxhash.Sum64(k)}
 	case byte:
-		return uint64(k)
+		return [2]uint64{uint64(k), 0}
 	case int:
-		return uint64(k)
+		return [2]uint64{uint64(k), 0}
 	case int32:
-		return uint64(k)
+		return [2]uint64{uint64(k), 0}
 	case uint32:
-		return uint64(k)
+		return [2]uint64{uint64(k), 0}
 	case int64:
-		return uint64(k)
+		return [2]uint64{uint64(k), 0}
 	default:
 		panic("Key type not supported")
 	}

--- a/z/z.go
+++ b/z/z.go
@@ -17,16 +17,19 @@
 package z
 
 // KeyToHash interprets the type of key and converts it to a uint64 hash.
-func KeyToHash(key interface{}) uint64 {
+func KeyToHash(key interface{}, seed uint8) uint64 {
+	if key == nil {
+		return 0 + uint64(seed)
+	}
 	switch k := key.(type) {
 	case uint64:
 		return k
 	case string:
-		return MemHashString(k)
+		return MemHash(append([]byte(k), seed))
 	case []byte:
-		return MemHash(k)
+		return MemHash(append(k, seed))
 	case byte:
-		return MemHash([]byte{k})
+		return uint64(k)
 	case int:
 		return uint64(k)
 	case int32:

--- a/z/z.go
+++ b/z/z.go
@@ -20,28 +20,36 @@ import (
 	"github.com/cespare/xxhash"
 )
 
-func KeyToHash(key interface{}) [2]uint64 {
+// TODO: Figure out a way to re-use memhash for the second uint64 hash, we
+//       already know that appending bytes isn't reliable for generating a
+//       second hash (see Ristretto PR #88).
+//
+//       We also know that while the Go runtime has a runtime memhash128
+//       function, it's not possible to use it to generate [2]uint64 or
+//       anything resembling a 128bit hash, even though that's exactly what
+//       we need in this situation.
+func KeyToHash(key interface{}) (uint64, uint64) {
 	if key == nil {
-		return [2]uint64{0, 0}
+		return 0, 0
 	}
 	switch k := key.(type) {
 	case uint64:
-		return [2]uint64{k, 0}
+		return k, 0
 	case string:
 		raw := []byte(k)
-		return [2]uint64{MemHash(raw), xxhash.Sum64(raw)}
+		return MemHash(raw), xxhash.Sum64(raw)
 	case []byte:
-		return [2]uint64{MemHash(k), xxhash.Sum64(k)}
+		return MemHash(k), xxhash.Sum64(k)
 	case byte:
-		return [2]uint64{uint64(k), 0}
+		return uint64(k), 0
 	case int:
-		return [2]uint64{uint64(k), 0}
+		return uint64(k), 0
 	case int32:
-		return [2]uint64{uint64(k), 0}
+		return uint64(k), 0
 	case uint32:
-		return [2]uint64{uint64(k), 0}
+		return uint64(k), 0
 	case int64:
-		return [2]uint64{uint64(k), 0}
+		return uint64(k), 0
 	default:
 		panic("Key type not supported")
 	}

--- a/z/z_test.go
+++ b/z/z_test.go
@@ -21,22 +21,19 @@ import (
 	"testing"
 )
 
-func verifyHashProduct(t *testing.T, wants, got uint64) {
-	if wants != got {
-		t.Errorf("expected hash product to equal %d. Got %d", wants, got)
+func verifyHashProduct(t *testing.T, wants, got [2]uint64) {
+	if wants[0] != got[0] || wants[1] != got[1] {
+		t.Errorf("expected [2]uint64{%d, %d}, but got [2]uint64{%d, %d}\n",
+			wants[0], wants[1], got[0], got[1])
 	}
 }
 
 func TestKeyToHash(t *testing.T) {
-	verifyHashProduct(t, 1, KeyToHash(uint64(1), 0))
-	verifyHashProduct(t, 1, KeyToHash(1, 0))
-	verifyHashProduct(t, 2, KeyToHash(int32(2), 0))
-	verifyHashProduct(t, math.MaxUint64-1, KeyToHash(int32(-2), 0))
-	verifyHashProduct(t, math.MaxUint64-1, KeyToHash(int64(-2), 0))
-	verifyHashProduct(t, 3, KeyToHash(uint32(3), 0))
-	verifyHashProduct(t, 3, KeyToHash(int64(3), 0))
-  last := KeyToHash("data", 0)
-	if KeyToHash("data", 1) == last {
-		t.Fatal("seed not being used")
-	}
+	verifyHashProduct(t, [2]uint64{1, 0}, KeyToHash(uint64(1)))
+	verifyHashProduct(t, [2]uint64{1, 0}, KeyToHash(1))
+	verifyHashProduct(t, [2]uint64{2, 0}, KeyToHash(int32(2)))
+	verifyHashProduct(t, [2]uint64{math.MaxUint64 - 1, 0}, KeyToHash(int32(-2)))
+	verifyHashProduct(t, [2]uint64{math.MaxUint64 - 1, 0}, KeyToHash(int64(-2)))
+	verifyHashProduct(t, [2]uint64{3, 0}, KeyToHash(uint32(3)))
+	verifyHashProduct(t, [2]uint64{3, 0}, KeyToHash(int64(3)))
 }

--- a/z/z_test.go
+++ b/z/z_test.go
@@ -21,19 +21,35 @@ import (
 	"testing"
 )
 
-func verifyHashProduct(t *testing.T, wants, got [2]uint64) {
-	if wants[0] != got[0] || wants[1] != got[1] {
-		t.Errorf("expected [2]uint64{%d, %d}, but got [2]uint64{%d, %d}\n",
-			wants[0], wants[1], got[0], got[1])
+func verifyHashProduct(t *testing.T, wantKey, wantConflict, key, conflict uint64) {
+	if wantKey != key || wantConflict != conflict {
+		t.Errorf("expected (%d, %d) but got (%d, %d)\n",
+			wantKey, wantConflict, key, conflict)
 	}
 }
 
 func TestKeyToHash(t *testing.T) {
-	verifyHashProduct(t, [2]uint64{1, 0}, KeyToHash(uint64(1)))
-	verifyHashProduct(t, [2]uint64{1, 0}, KeyToHash(1))
-	verifyHashProduct(t, [2]uint64{2, 0}, KeyToHash(int32(2)))
-	verifyHashProduct(t, [2]uint64{math.MaxUint64 - 1, 0}, KeyToHash(int32(-2)))
-	verifyHashProduct(t, [2]uint64{math.MaxUint64 - 1, 0}, KeyToHash(int64(-2)))
-	verifyHashProduct(t, [2]uint64{3, 0}, KeyToHash(uint32(3)))
-	verifyHashProduct(t, [2]uint64{3, 0}, KeyToHash(int64(3)))
+	var key uint64
+	var conflict uint64
+
+	key, conflict = KeyToHash(uint64(1))
+	verifyHashProduct(t, 1, 0, key, conflict)
+
+	key, conflict = KeyToHash(1)
+	verifyHashProduct(t, 1, 0, key, conflict)
+
+	key, conflict = KeyToHash(int32(2))
+	verifyHashProduct(t, 2, 0, key, conflict)
+
+	key, conflict = KeyToHash(int32(-2))
+	verifyHashProduct(t, math.MaxUint64-1, 0, key, conflict)
+
+	key, conflict = KeyToHash(int64(-2))
+	verifyHashProduct(t, math.MaxUint64-1, 0, key, conflict)
+
+	key, conflict = KeyToHash(uint32(3))
+	verifyHashProduct(t, 3, 0, key, conflict)
+
+	key, conflict = KeyToHash(int64(3))
+	verifyHashProduct(t, 3, 0, key, conflict)
 }

--- a/z/z_test.go
+++ b/z/z_test.go
@@ -28,11 +28,15 @@ func verifyHashProduct(t *testing.T, wants, got uint64) {
 }
 
 func TestKeyToHash(t *testing.T) {
-	verifyHashProduct(t, 1, KeyToHash(uint64(1)))
-	verifyHashProduct(t, 1, KeyToHash(1))
-	verifyHashProduct(t, 2, KeyToHash(int32(2)))
-	verifyHashProduct(t, math.MaxUint64-1, KeyToHash(int32(-2)))
-	verifyHashProduct(t, math.MaxUint64-1, KeyToHash(int64(-2)))
-	verifyHashProduct(t, 3, KeyToHash(uint32(3)))
-	verifyHashProduct(t, 3, KeyToHash(int64(3)))
+	verifyHashProduct(t, 1, KeyToHash(uint64(1), 0))
+	verifyHashProduct(t, 1, KeyToHash(1, 0))
+	verifyHashProduct(t, 2, KeyToHash(int32(2), 0))
+	verifyHashProduct(t, math.MaxUint64-1, KeyToHash(int32(-2), 0))
+	verifyHashProduct(t, math.MaxUint64-1, KeyToHash(int64(-2), 0))
+	verifyHashProduct(t, 3, KeyToHash(uint32(3), 0))
+	verifyHashProduct(t, 3, KeyToHash(int64(3), 0))
+  last := KeyToHash("data", 0)
+	if KeyToHash("data", 1) == last {
+		t.Fatal("seed not being used")
+	}
 }


### PR DESCRIPTION
If a user Set 30,000,000 items per second for 30 days straight and *no items are evicted*, the probability of a collision is [0.000000000008](https://www.wolframalpha.com/input/?i=1+-+0.99999999999111529396206131061107524980862386359199594804) or 8 x 10<sup>-12</sup>.

If there is a collision, Ristretto will notice and not process the request (Get/Set/Del).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/98)
<!-- Reviewable:end -->
