### PR TITLE
#96 Fixes memory leak due to Oct 1st regression in processItems

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -268,22 +268,23 @@ func (c *Cache) processItems() {
 			}
 			switch i.flag {
 			case itemNew:
-				if victims, added := c.policy.Add(i.keyHash, i.cost); added {
+				victims, added := c.policy.Add(i.keyHash, i.cost);
+				if added {
 					// item was accepted by the policy, so add to the hashmap
 					c.store.Set(i.keyHash, i.key, i.value)
-					// delete victims
-					for _, victim := range victims {
-						// TODO: make Get-Delete atomic
-						if c.onEvict != nil {
-							// force get with no collision checking because
-							// we don't have access to the victim's key
-							victim.value, _ = c.store.Get(victim.keyHash, nil)
-							c.onEvict(victim.keyHash, victim.value, victim.cost)
-						}
-						// force delete with no collision checking because we
-						// don't have access to the original, unhashed key
-						c.store.Del(victim.keyHash, nil)
+				}
+				// delete victims
+				for _, victim := range victims {
+					// TODO: make Get-Delete atomic
+					if c.onEvict != nil {
+						// force get with no collision checking because
+						// we don't have access to the victim's key
+						victim.value, _ = c.store.Get(victim.keyHash, nil)
+						c.onEvict(victim.keyHash, victim.value, victim.cost)
 					}
+					// force delete with no collision checking because we
+					// don't have access to the original, unhashed key
+					c.store.Del(victim.keyHash, nil)
 				}
 			case itemUpdate:
 				c.policy.Update(i.keyHash, i.cost)


### PR DESCRIPTION
See #96 

---

I ran the proof with two different versions of ristretto and got 2 different results.  
This is definitely a regression.

Found the offending commit  
https://github.com/dgraph-io/ristretto/commit/d963fa241740c4012b003362a7602e6ae764b104

```
$ go get github.com/dgraph-io/ristretto@d963fa241740c4012b003362a7602e6ae764b104
go: finding github.com/dgraph-io/ristretto d963fa241740c4012b003362a7602e6ae764b104
go: downloading github.com/dgraph-io/ristretto v0.0.0-20191001142246-d963fa241740
go: extracting github.com/dgraph-io/ristretto v0.0.0-20191001142246-d963fa241740

$ go run ristretto-bug.go
time: 1s alloc: 1034.71 MiB hits: 75 misses: 3747
time: 2s alloc: 1043.73 MiB hits: 117 misses: 4378
time: 3s alloc: 1050.75 MiB hits: 109 misses: 4374
time: 4s alloc: 1076.77 MiB hits: 138 misses: 4339
time: 5s alloc: 1126.79 MiB hits: 178 misses: 4337

$ go get github.com/dgraph-io/ristretto@7028ca5adaaeebef6f8498040b8a77189a4387b2
go: finding github.com/dgraph-io/ristretto 7028ca5adaaeebef6f8498040b8a77189a4387b2
go: downloading github.com/dgraph-io/ristretto v0.0.0-20190930223733-7028ca5adaae
go: extracting github.com/dgraph-io/ristretto v0.0.0-20190930223733-7028ca5adaae

$ go run ristretto-bug.go
time: 1s alloc: 1040.71 MiB hits: 78 misses: 3807
time: 2s alloc: 1031.72 MiB hits: 105 misses: 4403
time: 3s alloc: 1030.73 MiB hits: 110 misses: 4373
time: 4s alloc: 1036.74 MiB hits: 114 misses: 4335
time: 5s alloc: 1029.75 MiB hits: 107 misses: 4370
```

Reading the diff I saw a logic change that looked like an error since `policy.Add` can, in some cases, return `victims` when `added` is false.  
https://github.com/dgraph-io/ristretto/blob/master/policy.go#L168
```go
// Before Oct 1st

victims, added := c.policy.Add(item.key, item.cost)
if added {
	// ...
}
for _, victim := range victims {
	// ...
}
```
```go
// After Oct 1st commit

if victims, added := c.policy.Add(item.key, item.cost); added {
	// ...
	for _, victim := range victims {
		// ...
	}
}
```
This commit extracts the for loop from the if statement, fixing the memory leak.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/99)
<!-- Reviewable:end -->
