### PR TITLE
add cache test for identifying MaxCost overflows

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -1,6 +1,8 @@
 package ristretto
 
 import (
+	"math/rand"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -286,30 +288,57 @@ func TestCacheMetrics(t *testing.T) {
 }
 
 func TestCacheMaxCost(t *testing.T) {
+	charset := "abcdefghijklmnopqrstuvwxyz0123456789"
+	key := func() []byte {
+		k := make([]byte, 2)
+		for i := range k {
+			k[i] = charset[rand.Intn(len(charset))]
+		}
+		return k
+	}
 	c, err := NewCache(&Config{
-		NumCounters: 1000,
-		MaxCost:     100,
+		NumCounters: 12960, // 36^2 * 10
+		MaxCost:     1e6,   // 1mb
 		BufferItems: 64,
 		Metrics:     true,
 	})
 	if err != nil {
 		panic(err)
 	}
-	oldSize, iter := uint64(0), 0
-	for i := 0; i < 1000; i++ {
-		if i != 0 {
-			c.Get(i)
-		}
-		c.Set(i, i, 1)
-		newSize := c.store.Size()
-		if newSize > 100 && newSize > oldSize {
-			oldSize = newSize
-			if iter++; iter > 5 {
-				t.Fatal("cache size exceeding MaxCost")
+	stop := make(chan struct{}, 8)
+	for i := 0; i < 8; i++ {
+		go func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					time.Sleep(time.Millisecond)
+
+					k := key()
+					if _, ok := c.Get(k); !ok {
+						val := ""
+						if rand.Intn(100) < 10 {
+							val = "test"
+						} else {
+							val = strings.Repeat("a", 1000)
+						}
+						c.Set(key(), val, int64(2+len(val)))
+					}
+				}
 			}
-		} else {
-			oldSize, iter = 0, 0
+		}()
+	}
+	for i := 0; i < 20; i++ {
+		time.Sleep(time.Second)
+		cacheCost := c.Metrics.CostAdded() - c.Metrics.CostEvicted()
+		t.Logf("total cache cost: %d\n", cacheCost)
+		if float64(cacheCost) > float64(1e6*1.05) {
+			t.Fatal("cache cost exceeding MaxCost")
 		}
+	}
+	for i := 0; i < 8; i++ {
+		stop <- struct{}{}
 	}
 }
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,7 +1,6 @@
 package ristretto
 
 import (
-	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -287,7 +286,6 @@ func TestCacheMetrics(t *testing.T) {
 }
 
 func TestCacheMaxCost(t *testing.T) {
-	runtime.MemProfileRate = 1
 	c, err := NewCache(&Config{
 		NumCounters: 1000,
 		MaxCost:     100,

--- a/policy.go
+++ b/policy.go
@@ -269,15 +269,11 @@ func (p *sampledLFU) del(key uint64) {
 	if !ok {
 		return
 	}
-	p.metrics.add(keyEvict, key, 1)
-	p.metrics.add(costEvict, key, uint64(cost))
 	p.used -= cost
 	delete(p.keyCosts, key)
 }
 
 func (p *sampledLFU) add(key uint64, cost int64) {
-	p.metrics.add(keyAdd, key, 1)
-	p.metrics.add(costAdd, key, uint64(cost))
 	p.keyCosts[key] = cost
 	p.used += cost
 }

--- a/store.go
+++ b/store.go
@@ -47,6 +47,7 @@ type store interface {
 	Update(uint64, interface{}, interface{}) bool
 	// Clear clears all contents of the store.
 	Clear()
+	Size() uint64
 }
 
 // newStore returns the default store implementation.
@@ -90,6 +91,16 @@ func (sm *shardedMap) Clear() {
 	for i := uint64(0); i < numShards; i++ {
 		sm.shards[i].Clear()
 	}
+}
+
+func (sm *shardedMap) Size() uint64 {
+	total := uint64(0)
+	for _, shard := range sm.shards {
+		shard.RLock()
+		total += uint64(len(shard.data))
+		shard.RUnlock()
+	}
+	return total
 }
 
 type lockedMap struct {

--- a/store.go
+++ b/store.go
@@ -47,7 +47,6 @@ type store interface {
 	Update(uint64, interface{}, interface{}) bool
 	// Clear clears all contents of the store.
 	Clear()
-	Size() uint64
 }
 
 // newStore returns the default store implementation.
@@ -91,16 +90,6 @@ func (sm *shardedMap) Clear() {
 	for i := uint64(0); i < numShards; i++ {
 		sm.shards[i].Clear()
 	}
-}
-
-func (sm *shardedMap) Size() uint64 {
-	total := uint64(0)
-	for _, shard := range sm.shards {
-		shard.RLock()
-		total += uint64(len(shard.data))
-		shard.RUnlock()
-	}
-	return total
 }
 
 type lockedMap struct {


### PR DESCRIPTION
This is to prevent issues like #96 in the future. Ideally we'd have something that takes less than 20 seconds, but I think the stress testing is worth it. Due to the nature of Ristretto's eviction, I allow for no more than 5% MaxCost overflow.

Thanks @erikdubbelboer for identifying and providing code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/100)
<!-- Reviewable:end -->
