### PR TITLE
delete item immediately

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -216,7 +216,10 @@ func (c *Cache) Del(key interface{}) {
 		return
 	}
 	keyHash, conflictHash := c.keyToHash(key)
+	// Delete immediately.
 	c.store.Del(keyHash, conflictHash)
+	// we have push to the channel, beacuse if there is already set, it would be applied slightly
+	// So, delete won't happen. It is important to push deleteItem to channel as well.
 	c.setBuf <- &item{
 		flag:     itemDelete,
 		key:      keyHash,

--- a/cache.go
+++ b/cache.go
@@ -280,6 +280,7 @@ func (c *Cache) processItems() {
 
 			case itemDelete:
 				c.policy.Del(i.key) // Deals with metrics updates.
+				c.store.Del(i.key, i.conflict)
 			}
 		case <-c.stop:
 			return

--- a/cache.go
+++ b/cache.go
@@ -218,8 +218,9 @@ func (c *Cache) Del(key interface{}) {
 	keyHash, conflictHash := c.keyToHash(key)
 	// Delete immediately.
 	c.store.Del(keyHash, conflictHash)
-	// we have push to the channel, beacuse if there is already set, it would be applied slightly
-	// So, delete won't happen. It is important to push deleteItem to channel as well.
+	// If we've set an item, it would be applied slightly later.
+	// So we must push the same item to `setBuf` with the deletion flag.
+	// This ensures that if a set is followed by a delete, it will be applied in the correct order.
 	c.setBuf <- &item{
 		flag:     itemDelete,
 		key:      keyHash,

--- a/cache.go
+++ b/cache.go
@@ -216,6 +216,7 @@ func (c *Cache) Del(key interface{}) {
 		return
 	}
 	keyHash, conflictHash := c.keyToHash(key)
+	c.store.Del(keyHash, conflictHash)
 	c.setBuf <- &item{
 		flag:     itemDelete,
 		key:      keyHash,
@@ -279,7 +280,6 @@ func (c *Cache) processItems() {
 
 			case itemDelete:
 				c.policy.Del(i.key) // Deals with metrics updates.
-				c.store.Del(i.key, i.conflict)
 			}
 		case <-c.stop:
 			return

--- a/cache_test.go
+++ b/cache_test.go
@@ -170,20 +170,6 @@ func TestCacheProcessItems(t *testing.T) {
 	if c.policy.Cost(1) != 2 {
 		t.Fatal("cache processItems didn't update item cost")
 	}
-	key, conflict = z.KeyToHash(1)
-	c.setBuf <- &item{
-		flag:     itemDelete,
-		key:      key,
-		conflict: conflict,
-	}
-	time.Sleep(wait)
-	key, conflict = z.KeyToHash(1)
-	if val, ok := c.store.Get(key, conflict); val != nil || ok {
-		t.Fatal("cache processItems didn't delete item")
-	}
-	if c.policy.Has(1) {
-		t.Fatal("cache processItems didn't delete item")
-	}
 	key, conflict = z.KeyToHash(2)
 	c.setBuf <- &item{
 		flag:     itemNew,
@@ -321,7 +307,6 @@ func TestCacheDel(t *testing.T) {
 	}
 	c.Set(1, 1, 1)
 	c.Del(1)
-	time.Sleep(wait)
 	if val, ok := c.Get(1); val != nil || ok {
 		t.Fatal("del didn't delete")
 	}

--- a/cache_test.go
+++ b/cache_test.go
@@ -142,7 +142,6 @@ func TestCacheProcessItems(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-
 	var key uint64
 	var conflict uint64
 
@@ -169,6 +168,20 @@ func TestCacheProcessItems(t *testing.T) {
 	time.Sleep(wait)
 	if c.policy.Cost(1) != 2 {
 		t.Fatal("cache processItems didn't update item cost")
+	}
+	key, conflict = z.KeyToHash(1)
+	c.setBuf <- &item{
+		flag:     itemDelete,
+		key:      key,
+		conflict: conflict,
+	}
+	time.Sleep(wait)
+	key, conflict = z.KeyToHash(1)
+	if val, ok := c.store.Get(key, conflict); val != nil || ok {
+		t.Fatal("cache processItems didn't delete item")
+	}
+	if c.policy.Has(1) {
+		t.Fatal("cache processItems didn't delete item")
 	}
 	key, conflict = z.KeyToHash(2)
 	c.setBuf <- &item{

--- a/policy_test.go
+++ b/policy_test.go
@@ -70,7 +70,7 @@ func TestPolicyAdd(t *testing.T) {
 	p.admit.Increment(2)
 	p.admit.Increment(3)
 	p.Unlock()
-	if victims, added := p.Add(1, 1); victims != nil || !added {
+	if victims, added := p.Add(1, 1); victims != nil || added {
 		t.Fatal("item should already exist")
 	}
 	if victims, added := p.Add(2, 20); victims != nil || !added {


### PR DESCRIPTION
Delete was happening concurrently in a separate goroutine. This will make the delete happen immediately But the pitfall is that if there is a set in the channel it'll bring the item again. So, we're pushing to the channel as well to maintain the order. 
Signed-off-by: balaji <balaji@dgraph.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/113)
<!-- Reviewable:end -->
