### PR TITLE
Add benchmarks for math.rand and fastrand

### DIFF
--- a/z/rtutil_test.go
+++ b/z/rtutil_test.go
@@ -285,6 +285,7 @@ func benchmarkRand(b *testing.B, fab func() func() uint32) {
 		}
 	})
 }
+
 func BenchmarkFastRand(b *testing.B) {
 	benchmarkRand(b, func() func() uint32 {
 		return FastRand
@@ -303,6 +304,7 @@ func BenchmarkRandGlobal(b *testing.B) {
 		return func() uint32 { return rand.Uint32() }
 	})
 }
+
 func BenchmarkRandAtomic(b *testing.B) {
 	var x uint32
 	benchmarkRand(b, func() func() uint32 {

--- a/z/rtutil_test.go
+++ b/z/rtutil_test.go
@@ -268,6 +268,15 @@ func BenchmarkCPUTicks(b *testing.B) {
 	}
 }
 
+// goos: linux
+// goarch: amd64
+// pkg: github.com/dgraph-io/ristretto/z
+// BenchmarkFastRand-16      	1000000000	         0.292 ns/op
+// BenchmarkRandSource-16    	1000000000	         0.747 ns/op
+// BenchmarkRandGlobal-16    	 6822332	       176 ns/op
+// BenchmarkRandAtomic-16    	77950322	        15.4 ns/op
+// PASS
+// ok  	github.com/dgraph-io/ristretto/z	4.808s
 func benchmarkRand(b *testing.B, fab func() func() uint32) {
 	b.RunParallel(func(pb *testing.PB) {
 		gen := fab()


### PR DESCRIPTION
This PR adds benchmarks for `fastRand`, `math.Rand`, `rand with new source`, etc.

These are the benchmark results.
```
goos: linux
goarch: amd64
pkg: github.com/dgraph-io/ristretto/z
BenchmarkFastRand-16      	1000000000	         0.292 ns/op
BenchmarkRandSource-16    	1000000000	         0.747 ns/op
BenchmarkRandGlobal-16    	 6822332	       176 ns/op
BenchmarkRandAtomic-16    	77950322	        15.4 ns/op
PASS
ok  	github.com/dgraph-io/ristretto/z	4.808s
```
Benchmarks inspired by https://go-review.googlesource.com/c/go/+/34781/1/src/runtime/rand_test.go#20

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/118)
<!-- Reviewable:end -->
