### PR TITLE
Use sync.Pool to use &item{}

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -610,6 +610,22 @@ func TestCacheMetricsClear(t *testing.T) {
 	c.Metrics.Clear()
 }
 
+func BenchmarkConcurrentCacheSetNeverEvict(b *testing.B) {
+	c, err := NewCache(&Config{
+		NumCounters: 100,
+		MaxCost:     10,
+		BufferItems: 64,
+	})
+	require.NoError(b, err)
+	b.RunParallel(func(pb *testing.PB) {
+		cnt := rand.Int()
+		for pb.Next() {
+			cnt++
+			c.Set(cnt, cnt, 0)
+		}
+	})
+}
+
 func init() {
 	// Set bucketSizeSecs to 1 to avoid waiting too much during the tests.
 	bucketDurationSecs = 1

--- a/policy.go
+++ b/policy.go
@@ -175,11 +175,9 @@ func (p *defaultPolicy) Add(key uint64, cost int64) ([]*item, bool) {
 		sample[minId] = sample[len(sample)-1]
 		sample = sample[:len(sample)-1]
 		// Store victim in evicted victims slice.
-		victims = append(victims, &item{
-			key:      minKey,
-			conflict: 0,
-			cost:     minCost,
-		})
+		i := itemPool.Get().(*item)
+		i.key, i.conflict, i.cost = minKey, 0, minCost
+		victims = append(victims, i)
 	}
 	p.evict.add(key, cost)
 	p.metrics.add(costAdd, key, uint64(cost))


### PR DESCRIPTION
```
benchmark                                    old ns/op     new ns/op     delta
BenchmarkConcurrentCacheSetNeverEvict-12     96.3          127           +31.88%

benchmark                                    old allocs     new allocs     delta
BenchmarkConcurrentCacheSetNeverEvict-12     3              2              -33.33%

benchmark                                    old bytes     new bytes     delta
BenchmarkConcurrentCacheSetNeverEvict-12     110           108           -1.82%
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/136)
<!-- Reviewable:end -->
