### PR TITLE
z: use MemHashString and xxhash.Sum64String

### DIFF
--- a/z/rtutil_test.go
+++ b/z/rtutil_test.go
@@ -13,9 +13,24 @@ import (
 func BenchmarkMemHash(b *testing.B) {
 	buf := make([]byte, 64)
 	rand.Read(buf)
+
+	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		MemHash(buf)
+		_ = MemHash(buf)
 	}
+	b.SetBytes(int64(len(buf)))
+}
+
+func BenchmarkMemHashString(b *testing.B) {
+	s := "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = MemHashString(s)
+	}
+	b.SetBytes(int64(len(s)))
 }
 
 func BenchmarkSip(b *testing.B) {

--- a/z/z.go
+++ b/z/z.go
@@ -36,8 +36,7 @@ func KeyToHash(key interface{}) (uint64, uint64) {
 	case uint64:
 		return k, 0
 	case string:
-		raw := []byte(k)
-		return MemHash(raw), xxhash.Sum64(raw)
+		return MemHashString(k), xxhash.Sum64String(k)
 	case []byte:
 		return MemHash(k), xxhash.Sum64(k)
 	case byte:


### PR DESCRIPTION
Use MemHashString and xxhash.Sum64String for `KeyToHash`.

```console
$ go test -v -run='^$' -bench=. -benchmem -count 10 ./... | tee {old,new}.txt
$ benchstat -geomean old.txt new.txt
name                old time/op    new time/op     delta
pkg:github.com/dgraph-io/ristretto goos:darwin goarch:amd64
SketchIncrement-16    10.4ns ± 6%      8.4ns ± 3%  -18.84%  (p=0.000 n=10+10)
SketchEstimate-16     11.7ns ± 6%      9.8ns ± 6%  -16.26%  (p=0.000 n=10+10)
StoreGet-16           66.3ns ± 8%     55.6ns ± 9%  -16.20%  (p=0.000 n=10+9)
StoreSet-16            307ns ± 3%      297ns ± 6%     ~     (p=0.062 n=9+10)
StoreUpdate-16         294ns ± 6%      281ns ±10%     ~     (p=0.101 n=10+10)
pkg:github.com/dgraph-io/ristretto/z goos:darwin goarch:amd64
M_New-16              17.1µs ± 4%     16.9µs ± 8%     ~     (p=0.971 n=10+10)
M_Clear-16            2.31µs ± 6%     2.06µs ± 7%  -10.65%  (p=0.000 n=10+10)
M_Add-16              1.96ms ± 2%     1.89ms ± 5%   -3.61%  (p=0.004 n=10+10)
M_Has-16              1.84ms ± 9%     1.81ms ± 8%     ~     (p=0.529 n=10+10)
MemHash-16            6.26ns ± 2%     6.25ns ± 8%     ~     (p=0.858 n=9+10)
MemHashString-16      10.3ns ± 2%     10.3ns ± 4%     ~     (p=0.661 n=10+10)
Sip-16                40.1ns ± 5%     38.5ns ± 6%   -4.04%  (p=0.016 n=10+10)
Farm-16               7.95ns ± 4%     7.28ns ± 6%   -8.37%  (p=0.000 n=10+9)
Fnv-16                54.1ns ± 2%     52.8ns ± 6%     ~     (p=0.106 n=8+10)
NanoTime-16           32.9ns ± 3%     31.8ns ± 4%   -3.50%  (p=0.003 n=9+10)
CPUTicks-16           10.7ns ± 6%     10.6ns ± 5%     ~     (p=0.421 n=10+10)
FastRand-16           0.50ns ±18%     0.47ns ±20%     ~     (p=0.271 n=10+10)
RandSource-16         1.34ns ±12%     1.29ns ±10%     ~     (p=0.322 n=9+10)
RandGlobal-16         84.0ns ± 6%     80.0ns ± 3%   -4.71%  (p=0.000 n=9+9)
RandAtomic-16         25.1ns ± 2%     23.2ns ± 5%   -7.65%  (p=0.000 n=10+10)

[Geo mean]             109ns           102ns        -6.04%

name                old speed      new speed       delta
pkg:github.com/dgraph-io/ristretto goos:darwin goarch:amd64
SketchIncrement-16  96.5MB/s ± 6%  118.8MB/s ± 3%  +23.12%  (p=0.000 n=10+10)
SketchEstimate-16   85.7MB/s ± 6%  102.5MB/s ± 6%  +19.58%  (p=0.000 n=10+10)
StoreGet-16         15.1MB/s ± 9%   17.7MB/s ±17%  +17.09%  (p=0.000 n=10+10)
StoreSet-16         3.26MB/s ± 3%   3.37MB/s ± 7%     ~     (p=0.083 n=9+10)
StoreUpdate-16      3.40MB/s ± 6%   3.58MB/s ±10%     ~     (p=0.109 n=10+10)
pkg:github.com/dgraph-io/ristretto/z goos:darwin goarch:amd64
MemHash-16          10.2GB/s ± 2%   10.3GB/s ± 8%     ~     (p=0.905 n=9+10)
MemHashString-16    11.9GB/s ± 2%   12.0GB/s ± 4%     ~     (p=0.739 n=10+10)

[Geo mean]           108MB/s         118MB/s        +9.51%

name                old alloc/op   new alloc/op    delta
pkg:github.com/dgraph-io/ristretto goos:darwin goarch:amd64
SketchIncrement-16     0.00B           0.00B          ~     (all equal)
SketchEstimate-16      0.00B           0.00B          ~     (all equal)
StoreGet-16            0.00B           0.00B          ~     (all equal)
StoreSet-16            80.0B ± 0%      80.0B ± 0%     ~     (all equal)
StoreUpdate-16         80.0B ± 0%      80.0B ± 0%     ~     (all equal)
pkg:github.com/dgraph-io/ristretto/z goos:darwin goarch:amd64
M_New-16               131kB ± 0%      131kB ± 0%     ~     (all equal)
M_Clear-16             0.00B           0.00B          ~     (all equal)
M_Add-16               0.00B           0.00B          ~     (all equal)
M_Has-16               0.00B           0.00B          ~     (all equal)
MemHash-16             0.00B           0.00B          ~     (all equal)
MemHashString-16       0.00B           0.00B          ~     (all equal)
Sip-16                 0.00B           0.00B          ~     (all equal)
Farm-16                0.00B           0.00B          ~     (all equal)
Fnv-16                 0.00B           0.00B          ~     (all equal)
NanoTime-16            0.00B           0.00B          ~     (all equal)
CPUTicks-16            0.00B           0.00B          ~     (all equal)
FastRand-16            0.00B           0.00B          ~     (all equal)
RandSource-16          0.00B           0.00B          ~     (all equal)
RandGlobal-16          0.00B           0.00B          ~     (all equal)
RandAtomic-16          0.00B           0.00B          ~     (all equal)

[Geo mean]              943B            943B        +0.00%

name                old allocs/op  new allocs/op   delta
pkg:github.com/dgraph-io/ristretto goos:darwin goarch:amd64
SketchIncrement-16      0.00            0.00          ~     (all equal)
SketchEstimate-16       0.00            0.00          ~     (all equal)
StoreGet-16             0.00            0.00          ~     (all equal)
StoreSet-16             1.00 ± 0%       1.00 ± 0%     ~     (all equal)
StoreUpdate-16          1.00 ± 0%       1.00 ± 0%     ~     (all equal)
pkg:github.com/dgraph-io/ristretto/z goos:darwin goarch:amd64
M_New-16                2.00 ± 0%       2.00 ± 0%     ~     (all equal)
M_Clear-16              0.00            0.00          ~     (all equal)
M_Add-16                0.00            0.00          ~     (all equal)
M_Has-16                0.00            0.00          ~     (all equal)
MemHash-16              0.00            0.00          ~     (all equal)
MemHashString-16        0.00            0.00          ~     (all equal)
Sip-16                  0.00            0.00          ~     (all equal)
Farm-16                 0.00            0.00          ~     (all equal)
Fnv-16                  0.00            0.00          ~     (all equal)
NanoTime-16             0.00            0.00          ~     (all equal)
CPUTicks-16             0.00            0.00          ~     (all equal)
FastRand-16             0.00            0.00          ~     (all equal)
RandSource-16           0.00            0.00          ~     (all equal)
RandGlobal-16           0.00            0.00          ~     (all equal)
RandAtomic-16           0.00            0.00          ~     (all equal)

[Geo mean]              1.26            1.26        +0.00%
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/153)
<!-- Reviewable:end -->
