### PR TITLE
Check conflict key before updating expiration map.

### DIFF
--- a/store.go
+++ b/store.go
@@ -161,7 +161,7 @@ func (m *lockedMap) Set(i *item) {
 
 	if ok {
 		// The item existed already. We need to check the conflict key and reject the
-		// update if they do not match. The nwe update the expiration map.
+		// update if they do not match. Only after that the expiration map is updated.
 		if i.conflict != 0 && (i.conflict != item.conflict) {
 			return
 		}


### PR DESCRIPTION
When setting keys, the check of the conflict key is happening
after the expiration map is updated but the order of these two
operations should be reversed.

Also refactor the logic in this method for easier readability.

Fixes #149

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/154)
<!-- Reviewable:end -->
