### PR TITLE
Avoid copy/allocation in KeyToHash for string keys

### DIFF
--- a/z/z.go
+++ b/z/z.go
@@ -36,8 +36,7 @@ func KeyToHash(key interface{}) (uint64, uint64) {
 	case uint64:
 		return k, 0
 	case string:
-		raw := []byte(k)
-		return MemHash(raw), xxhash.Sum64(raw)
+		return MemHashString(k), xxhash.Sum64String(k)
 	case []byte:
 		return MemHash(k), xxhash.Sum64(k)
 	case byte:


### PR DESCRIPTION
Replaces the byte slice allocation with string specific hashing functions which should be faster/less expensive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/157)
<!-- Reviewable:end -->
