### PR TITLE
 ristretto/z: use hash/memhash for hashing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/dgraph-io/ristretto
 go 1.12
 
 require (
-	github.com/cespare/xxhash v1.1.0
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,15 +1,9 @@
-github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
-github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
-github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
-github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/z/rtutil.go
+++ b/z/rtutil.go
@@ -23,7 +23,7 @@
 package z
 
 import (
-	"unsafe"
+	_ "unsafe" // Allow go:linkname directives.
 )
 
 // NanoTime returns the current time in nanoseconds from a monotonic clock.
@@ -34,29 +34,18 @@ func NanoTime() int64
 //go:linkname CPUTicks runtime.cputicks
 func CPUTicks() int64
 
-type stringStruct struct {
-	str unsafe.Pointer
-	len int
-}
-
-//go:noescape
-//go:linkname memhash runtime.memhash
-func memhash(p unsafe.Pointer, h, s uintptr) uintptr
-
 // MemHash is the hash function used by go map, it utilizes available hardware instructions(behaves
 // as aeshash if aes instruction is available).
 // NOTE: The hash seed changes for every process. So, this cannot be used as a persistent hash.
 func MemHash(data []byte) uint64 {
-	ss := (*stringStruct)(unsafe.Pointer(&data))
-	return uint64(memhash(ss.str, 0, uintptr(ss.len)))
+	return memHash(seed1, data)
 }
 
 // MemHashString is the hash function used by go map, it utilizes available hardware instructions
 // (behaves as aeshash if aes instruction is available).
 // NOTE: The hash seed changes for every process. So, this cannot be used as a persistent hash.
 func MemHashString(str string) uint64 {
-	ss := (*stringStruct)(unsafe.Pointer(&str))
-	return uint64(memhash(ss.str, 0, uintptr(ss.len)))
+	return memHashString(seed1, str)
 }
 
 // FastRand is a fast thread local random function.


### PR DESCRIPTION
This is cleaner, but unfortunately slower.

Reusing the Hash value in KeyToHash may help there,
but wouldn't get back to the original speed, so maybe
this isn't a reasonable change.

```
name             old time/op    new time/op    delta
MemHash-4          12.4ns ± 7%    43.1ns ± 1%  +248.30%  (p=0.008 n=5+5)
MemHashString-4    19.6ns ± 7%    70.9ns ±20%  +262.00%  (p=0.008 n=5+5)

name             old speed      new speed      delta
MemHash-4        5.17GB/s ± 7%  1.48GB/s ± 0%   -71.31%  (p=0.008 n=5+5)
MemHashString-4  6.29GB/s ± 6%  1.75GB/s ±18%   -72.12%  (p=0.008 n=5+5)

name             old alloc/op   new alloc/op   delta
MemHash-4           0.00B          0.00B           ~     (all equal)
MemHashString-4     0.00B          0.00B           ~     (all equal)

name             old allocs/op  new allocs/op  delta
MemHash-4            0.00           0.00           ~     (all equal)
MemHashString-4      0.00           0.00           ~     (all equal)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/160)
<!-- Reviewable:end -->
