### PR TITLE
Improve handling of updated items

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -29,7 +29,7 @@ import (
 	"github.com/dgraph-io/ristretto/z"
 )
 
-var (
+const (
 	// TODO: find the optimal value for this or make it configurable
 	setBufSize = 32 * 1024
 )
@@ -227,8 +227,7 @@ func (c *Cache) SetWithTTL(key, value interface{}, cost int64, ttl time.Duration
 	// cost is eventually updated. The expiration must also be immediately updated
 	// to prevent items from being prematurely removed from the map.
 	if c.store.Update(i) {
-		c.policy.Update(i.key, i.cost)
-		return true
+		i.flag = itemUpdate
 	}
 	// Attempt to send item to policy.
 	select {
@@ -325,6 +324,9 @@ func (c *Cache) processItems() {
 						c.onEvict(victim.key, victim.conflict, victim.value, victim.cost)
 					}
 				}
+
+			case itemUpdate:
+				c.policy.Update(i.key, i.cost)
 
 			case itemDelete:
 				c.policy.Del(i.key) // Deals with metrics updates.

--- a/cache.go
+++ b/cache.go
@@ -29,7 +29,7 @@ import (
 	"github.com/dgraph-io/ristretto/z"
 )
 
-const (
+var (
 	// TODO: find the optimal value for this or make it configurable
 	setBufSize = 32 * 1024
 )
@@ -235,7 +235,10 @@ func (c *Cache) SetWithTTL(key, value interface{}, cost int64, ttl time.Duration
 		return true
 	default:
 		c.Metrics.add(dropSets, keyHash, 1)
-		return false
+		// Return true if this was an update operation since we've already
+		// updated the store. For all the other operations (set/delete), we
+		// return false which means the item was not inserted.
+		return i.flag == itemUpdate
 	}
 }
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,7 +1,9 @@
 package ristretto
 
 import (
+	"fmt"
 	"math/rand"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -613,4 +615,57 @@ func TestCacheMetricsClear(t *testing.T) {
 func init() {
 	// Set bucketSizeSecs to 1 to avoid waiting too much during the tests.
 	bucketDurationSecs = 1
+}
+
+func TestUpdateBug(t *testing.T) {
+	originalSetBugSize := setBufSize
+	defer func() { setBufSize = originalSetBugSize }()
+
+	test := func() {
+		// dropppedMap stores the items dropped from the cache.
+		droppedMap := make(map[int]struct{})
+		lastEvictedSet := int64(-1)
+
+		var err error
+		handler := func(_ interface{}, value interface{}) {
+			v := value.(string)
+			lastEvictedSet, err = strconv.ParseInt(string(v), 10, 32)
+			require.NoError(t, err)
+
+			_, ok := droppedMap[int(lastEvictedSet)]
+			if ok {
+				panic(fmt.Sprintf("val = %+v was dropped but got evicted. Dropped items: %+v\n", lastEvictedSet, droppedMap))
+			}
+		}
+
+		// This is important.
+		setBufSize = 10
+
+		c, err := NewCache(&Config{
+			NumCounters: 100,
+			MaxCost:     10,
+			BufferItems: 64,
+			Metrics:     true,
+			OnEvict: func(_, _ uint64, value interface{}, _ int64) {
+				handler(nil, value)
+			},
+		})
+		require.NoError(t, err)
+
+		for i := 0; i < 5*setBufSize; i++ {
+			v := fmt.Sprintf("%0100d", i)
+			// We're updating the same key.
+			if !c.Set(0, v, 1) {
+				time.Sleep(time.Microsecond)
+				droppedMap[i] = struct{}{}
+			}
+		}
+		time.Sleep(time.Millisecond)
+		require.True(t, c.Set(1, nil, 10))
+		c.Close()
+	}
+	// Run the test 100 times.
+	for i := 0; i < 100; i++ {
+		test()
+	}
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -634,7 +634,8 @@ func TestUpdateBug(t *testing.T) {
 
 			_, ok := droppedMap[int(lastEvictedSet)]
 			if ok {
-				panic(fmt.Sprintf("val = %+v was dropped but got evicted. Dropped items: %+v\n", lastEvictedSet, droppedMap))
+				panic(fmt.Sprintf("val = %+v was dropped but it got evicted. Dropped items: %+v\n",
+					lastEvictedSet, droppedMap))
 			}
 		}
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,7 +1,9 @@
 package ristretto
 
 import (
+	"fmt"
 	"math/rand"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -613,4 +615,55 @@ func TestCacheMetricsClear(t *testing.T) {
 func init() {
 	// Set bucketSizeSecs to 1 to avoid waiting too much during the tests.
 	bucketDurationSecs = 1
+}
+
+func TestUpdateBug(t *testing.T) {
+	originalSetBugSize := setBufSize
+	defer func() { setBufSize = originalSetBugSize }()
+	test := func() {
+		droppedMap := make(map[int]struct{})
+		lastEvictedSet := int64(-1)
+
+		var err error
+		handler := func(_ interface{}, value interface{}) {
+			v := value.(string)
+			lastEvictedSet, err = strconv.ParseInt(string(v), 10, 32)
+			require.NoError(t, err)
+			_, ok := droppedMap[int(lastEvictedSet)]
+			if ok {
+				panic(fmt.Sprintf("val = %+v was dropped but got evicted. Dropped items: %+v\n", lastEvictedSet, droppedMap))
+			}
+		}
+
+		// This is important.
+		setBufSize = 10
+
+		c, err := NewCache(&Config{
+			NumCounters: 100,
+			MaxCost:     10,
+			BufferItems: 64,
+			Metrics:     true,
+			OnEvict: func(_, _ uint64, value interface{}, _ int64) {
+				handler(nil, value)
+			},
+		})
+		require.NoError(t, err)
+
+		for i := 0; i < 5*setBufSize; i++ {
+			v := fmt.Sprintf("%0100d", i)
+			// We're updating the same key.
+			if !c.Set(0, v, 1) {
+				time.Sleep(time.Microsecond)
+				// fmt.Println("failed", i)
+				droppedMap[i] = struct{}{}
+			}
+		}
+		time.Sleep(time.Millisecond)
+		require.True(t, c.Set(1, nil, 10))
+		c.Close()
+	}
+	// Run the test 100 times.
+	for i := 0; i < 100; i++ {
+		test()
+	}
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,9 +1,7 @@
 package ristretto
 
 import (
-	"fmt"
 	"math/rand"
-	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -615,55 +613,4 @@ func TestCacheMetricsClear(t *testing.T) {
 func init() {
 	// Set bucketSizeSecs to 1 to avoid waiting too much during the tests.
 	bucketDurationSecs = 1
-}
-
-func TestUpdateBug(t *testing.T) {
-	originalSetBugSize := setBufSize
-	defer func() { setBufSize = originalSetBugSize }()
-	test := func() {
-		droppedMap := make(map[int]struct{})
-		lastEvictedSet := int64(-1)
-
-		var err error
-		handler := func(_ interface{}, value interface{}) {
-			v := value.(string)
-			lastEvictedSet, err = strconv.ParseInt(string(v), 10, 32)
-			require.NoError(t, err)
-			_, ok := droppedMap[int(lastEvictedSet)]
-			if ok {
-				panic(fmt.Sprintf("val = %+v was dropped but got evicted. Dropped items: %+v\n", lastEvictedSet, droppedMap))
-			}
-		}
-
-		// This is important.
-		setBufSize = 10
-
-		c, err := NewCache(&Config{
-			NumCounters: 100,
-			MaxCost:     10,
-			BufferItems: 64,
-			Metrics:     true,
-			OnEvict: func(_, _ uint64, value interface{}, _ int64) {
-				handler(nil, value)
-			},
-		})
-		require.NoError(t, err)
-
-		for i := 0; i < 5*setBufSize; i++ {
-			v := fmt.Sprintf("%0100d", i)
-			// We're updating the same key.
-			if !c.Set(0, v, 1) {
-				time.Sleep(time.Microsecond)
-				// fmt.Println("failed", i)
-				droppedMap[i] = struct{}{}
-			}
-		}
-		time.Sleep(time.Millisecond)
-		require.True(t, c.Set(1, nil, 10))
-		c.Close()
-	}
-	// Run the test 100 times.
-	for i := 0; i < 100; i++ {
-		test()
-	}
 }


### PR DESCRIPTION
When an item is updated, the existing item was updated in the `store` but we might return false.
Update happens here https://github.com/dgraph-io/ristretto/blob/a093fe661329ba68a99a9c3a63674992355f40b1/cache.go#L229-L231
and the false is returned here https://github.com/dgraph-io/ristretto/blob/a093fe661329ba68a99a9c3a63674992355f40b1/cache.go#L232-L239

With this PR, we will always return true for updates, even if the policy wasn't updated. 
See #167 for more details.

Fixes https://github.com/dgraph-io/ristretto/issues/167

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/168)
<!-- Reviewable:end -->
