### PR TITLE
Fix flaky TestCacheDel test

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -431,6 +431,10 @@ func TestCacheDel(t *testing.T) {
 
 	c.Set(1, 1, 1)
 	c.Del(1)
+	// The deletes and sets are pushed through the setbuf. It might be possible
+	// that the delete is not processed before the following get is called. So
+	// wait for a millisecond for things to be processed.
+	time.Sleep(time.Millisecond)
 	val, ok := c.Get(1)
 	require.False(t, ok)
 	require.Nil(t, val)


### PR DESCRIPTION
The `TestCacheDel` test inserts an item and deletes it. The inserts and deletes are pushed through the `setBuf` channel.
The test would fail if the `Get` was done before the previous delete was performed. This test adds a sleep to ensure the `Get` happens only after the delete is done.

The failure can be reproduced locally by applying the following diff.
```diff
diff --git a/cache.go b/cache.go
index e48a48a..42a381f 100644
--- a/cache.go
+++ b/cache.go
@@ -247,6 +247,10 @@ func (c *Cache) Del(key interface{}) {
 	keyHash, conflictHash := c.keyToHash(key)
 	// Delete immediately.
 	c.store.Del(keyHash, conflictHash)
+
+	// This will fail the TestCacheDel test.
+	time.Sleep(time.Millisecond)
+
 	// If we've set an item, it would be applied slightly later.
 	// So we must push the same item to `setBuf` with the deletion flag.
 	// This ensures that if a set is followed by a delete, it will be
```

An example of the flaky crash https://travis-ci.org/github/dgraph-io/ristretto/jobs/703421284#L246

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/169)
<!-- Reviewable:end -->
