### PR TITLE
Expose cache item expiration

### DIFF
--- a/store_test.go
+++ b/store_test.go
@@ -1,10 +1,11 @@
 package ristretto
 
 import (
-	"github.com/dgraph-io/ristretto/z"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/dgraph-io/ristretto/z"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStoreSetGet(t *testing.T) {
@@ -43,11 +44,11 @@ func TestStoreExpiration(t *testing.T) {
 	key, conflict := z.KeyToHash(1)
 
 	expiration := time.Now().Add(1 * time.Second)
-	i := item{
-		key:        key,
-		conflict:   conflict,
-		value:      1,
-		expiration: expiration,
+	i := Item{
+		Key:        key,
+		Conflict:   conflict,
+		Value:      1,
+		Expiration: expiration,
 	}
 
 	s.Set(&i)

--- a/store_test.go
+++ b/store_test.go
@@ -59,7 +59,7 @@ func TestStoreExpiration(t *testing.T) {
 	require.Equal(t, expiration, ttl)
 
 	s.Del(key, conflict)
-	val, ok = s.Get(key, conflict)
+	_, ok = s.Get(key, conflict)
 	require.False(t, ok)
 
 	ttl = s.Expiration(key)


### PR DESCRIPTION
I'm contributing to a multi layer cache library that propagates entries from lower caches to upper ones and in order to do this in an effective manner, i need the TTL of the entry stored in ristretto.

I oscillated between adding Expiration and a GetWithTTL which would also return the item in addition to TTL. If you think a GetWithTTL it's a better alternative, let me know and i'll replace Expiration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/179)
<!-- Reviewable:end -->
