### PR TITLE
Make item public. Add a new onReject call for rejected items.

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -38,7 +38,7 @@ type policy interface {
 	// Add attempts to Add the key-cost pair to the Policy. It returns a slice
 	// of evicted keys and a bool denoting whether or not the key-cost pair
 	// was added. If it returns true, the key should be stored in cache.
-	Add(uint64, int64) ([]*item, bool)
+	Add(uint64, int64) ([]*Item, bool)
 	// Has returns true if the key exists in the Policy.
 	Has(uint64) bool
 	// Del deletes the key from the Policy.
@@ -121,7 +121,7 @@ func (p *defaultPolicy) Push(keys []uint64) bool {
 // Add decides whether the item with the given key and cost should be accepted by
 // the policy. It returns the list of victims that have been evicted and a boolean
 // indicating whether the incoming item should be accepted.
-func (p *defaultPolicy) Add(key uint64, cost int64) ([]*item, bool) {
+func (p *defaultPolicy) Add(key uint64, cost int64) ([]*Item, bool) {
 	p.Lock()
 	defer p.Unlock()
 
@@ -155,7 +155,7 @@ func (p *defaultPolicy) Add(key uint64, cost int64) ([]*item, bool) {
 	// O(lg N).
 	sample := make([]*policyPair, 0, lfuSample)
 	// As items are evicted they will be appended to victims.
-	victims := make([]*item, 0)
+	victims := make([]*Item, 0)
 
 	// Delete victims until there's enough space or a minKey is found that has
 	// more hits than incoming item.
@@ -185,10 +185,10 @@ func (p *defaultPolicy) Add(key uint64, cost int64) ([]*item, bool) {
 		sample[minId] = sample[len(sample)-1]
 		sample = sample[:len(sample)-1]
 		// Store victim in evicted victims slice.
-		victims = append(victims, &item{
-			key:      minKey,
-			conflict: 0,
-			cost:     minCost,
+		victims = append(victims, &Item{
+			Key:      minKey,
+			Conflict: 0,
+			Cost:     minCost,
 		})
 	}
 

--- a/store.go
+++ b/store.go
@@ -42,14 +42,14 @@ type store interface {
 	// Set adds the key-value pair to the Map or updates the value if it's
 	// already present. The key-value pair is passed as a pointer to an
 	// item object.
-	Set(*item)
+	Set(*Item)
 	// Del deletes the key-value pair from the Map.
 	Del(uint64, uint64) (uint64, interface{})
 	// Update attempts to update the key with a new value and returns true if
 	// successful.
-	Update(*item) bool
+	Update(*Item) bool
 	// Cleanup removes items that have an expired TTL.
-	Cleanup(policy policy, onEvict onEvictFunc)
+	Cleanup(policy policy, onEvict itemCallback)
 	// Clear clears all contents of the store.
 	Clear()
 }
@@ -85,24 +85,24 @@ func (sm *shardedMap) Expiration(key uint64) time.Time {
 	return sm.shards[key%numShards].Expiration(key)
 }
 
-func (sm *shardedMap) Set(i *item) {
+func (sm *shardedMap) Set(i *Item) {
 	if i == nil {
 		// If item is nil make this Set a no-op.
 		return
 	}
 
-	sm.shards[i.key%numShards].Set(i)
+	sm.shards[i.Key%numShards].Set(i)
 }
 
 func (sm *shardedMap) Del(key, conflict uint64) (uint64, interface{}) {
 	return sm.shards[key%numShards].Del(key, conflict)
 }
 
-func (sm *shardedMap) Update(newItem *item) bool {
-	return sm.shards[newItem.key%numShards].Update(newItem)
+func (sm *shardedMap) Update(newItem *Item) bool {
+	return sm.shards[newItem.Key%numShards].Update(newItem)
 }
 
-func (sm *shardedMap) Cleanup(policy policy, onEvict onEvictFunc) {
+func (sm *shardedMap) Cleanup(policy policy, onEvict itemCallback) {
 	sm.expiryMap.cleanup(sm, policy, onEvict)
 }
 
@@ -149,7 +149,7 @@ func (m *lockedMap) Expiration(key uint64) time.Time {
 	return m.data[key].expiration
 }
 
-func (m *lockedMap) Set(i *item) {
+func (m *lockedMap) Set(i *Item) {
 	if i == nil {
 		// If the item is nil make this Set a no-op.
 		return
@@ -157,26 +157,26 @@ func (m *lockedMap) Set(i *item) {
 
 	m.Lock()
 	defer m.Unlock()
-	item, ok := m.data[i.key]
+	item, ok := m.data[i.Key]
 
 	if ok {
 		// The item existed already. We need to check the conflict key and reject the
 		// update if they do not match. Only after that the expiration map is updated.
-		if i.conflict != 0 && (i.conflict != item.conflict) {
+		if i.Conflict != 0 && (i.Conflict != item.conflict) {
 			return
 		}
-		m.em.update(i.key, i.conflict, item.expiration, i.expiration)
+		m.em.update(i.Key, i.Conflict, item.expiration, i.Expiration)
 	} else {
 		// The value is not in the map already. There's no need to return anything.
 		// Simply add the expiration map.
-		m.em.add(i.key, i.conflict, i.expiration)
+		m.em.add(i.Key, i.Conflict, i.Expiration)
 	}
 
-	m.data[i.key] = storeItem{
-		key:        i.key,
-		conflict:   i.conflict,
-		value:      i.value,
-		expiration: i.expiration,
+	m.data[i.Key] = storeItem{
+		key:        i.Key,
+		conflict:   i.Conflict,
+		value:      i.Value,
+		expiration: i.Expiration,
 	}
 }
 
@@ -201,24 +201,24 @@ func (m *lockedMap) Del(key, conflict uint64) (uint64, interface{}) {
 	return item.conflict, item.value
 }
 
-func (m *lockedMap) Update(newItem *item) bool {
+func (m *lockedMap) Update(newItem *Item) bool {
 	m.Lock()
-	item, ok := m.data[newItem.key]
+	item, ok := m.data[newItem.Key]
 	if !ok {
 		m.Unlock()
 		return false
 	}
-	if newItem.conflict != 0 && (newItem.conflict != item.conflict) {
+	if newItem.Conflict != 0 && (newItem.Conflict != item.conflict) {
 		m.Unlock()
 		return false
 	}
 
-	m.em.update(newItem.key, newItem.conflict, item.expiration, newItem.expiration)
-	m.data[newItem.key] = storeItem{
-		key:        newItem.key,
-		conflict:   newItem.conflict,
-		value:      newItem.value,
-		expiration: newItem.expiration,
+	m.em.update(newItem.Key, newItem.Conflict, item.expiration, newItem.Expiration)
+	m.data[newItem.Key] = storeItem{
+		key:        newItem.Key,
+		conflict:   newItem.Conflict,
+		value:      newItem.Value,
+		expiration: newItem.Expiration,
 	}
 
 	m.Unlock()

--- a/store.go
+++ b/store.go
@@ -21,6 +21,7 @@ import (
 	"time"
 )
 
+// TODO: Do we need this to be a separate struct from Item?
 type storeItem struct {
 	key        uint64
 	conflict   uint64

--- a/store_test.go
+++ b/store_test.go
@@ -10,27 +10,27 @@ import (
 func TestStoreSetGet(t *testing.T) {
 	s := newStore()
 	key, conflict := z.KeyToHash(1)
-	i := item{
-		key:      key,
-		conflict: conflict,
-		value:    2,
+	i := Item{
+		Key:      key,
+		Conflict: conflict,
+		Value:    2,
 	}
 	s.Set(&i)
 	val, ok := s.Get(key, conflict)
 	require.True(t, ok)
 	require.Equal(t, 2, val.(int))
 
-	i.value = 3
+	i.Value = 3
 	s.Set(&i)
 	val, ok = s.Get(key, conflict)
 	require.True(t, ok)
 	require.Equal(t, 3, val.(int))
 
 	key, conflict = z.KeyToHash(2)
-	i = item{
-		key:      key,
-		conflict: conflict,
-		value:    2,
+	i = Item{
+		Key:      key,
+		Conflict: conflict,
+		Value:    2,
 	}
 	s.Set(&i)
 	val, ok = s.Get(key, conflict)
@@ -41,10 +41,10 @@ func TestStoreSetGet(t *testing.T) {
 func TestStoreDel(t *testing.T) {
 	s := newStore()
 	key, conflict := z.KeyToHash(1)
-	i := item{
-		key:      key,
-		conflict: conflict,
-		value:    1,
+	i := Item{
+		Key:      key,
+		Conflict: conflict,
+		Value:    1,
 	}
 	s.Set(&i)
 	s.Del(key, conflict)
@@ -59,10 +59,10 @@ func TestStoreClear(t *testing.T) {
 	s := newStore()
 	for i := uint64(0); i < 1000; i++ {
 		key, conflict := z.KeyToHash(i)
-		it := item{
-			key:      key,
-			conflict: conflict,
-			value:    i,
+		it := Item{
+			Key:      key,
+			Conflict: conflict,
+			Value:    i,
 		}
 		s.Set(&it)
 	}
@@ -78,13 +78,13 @@ func TestStoreClear(t *testing.T) {
 func TestStoreUpdate(t *testing.T) {
 	s := newStore()
 	key, conflict := z.KeyToHash(1)
-	i := item{
-		key:      key,
-		conflict: conflict,
-		value:    1,
+	i := Item{
+		Key:      key,
+		Conflict: conflict,
+		Value:    1,
 	}
 	s.Set(&i)
-	i.value = 2
+	i.Value = 2
 	require.True(t, s.Update(&i))
 
 	val, ok := s.Get(key, conflict)
@@ -95,7 +95,7 @@ func TestStoreUpdate(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, 2, val.(int))
 
-	i.value = 3
+	i.Value = 3
 	require.True(t, s.Update(&i))
 
 	val, ok = s.Get(key, conflict)
@@ -103,10 +103,10 @@ func TestStoreUpdate(t *testing.T) {
 	require.Equal(t, 3, val.(int))
 
 	key, conflict = z.KeyToHash(2)
-	i = item{
-		key:      key,
-		conflict: conflict,
-		value:    2,
+	i = Item{
+		Key:      key,
+		Conflict: conflict,
+		Value:    2,
 	}
 	require.False(t, s.Update(&i))
 	val, ok = s.Get(key, conflict)
@@ -127,10 +127,10 @@ func TestStoreCollision(t *testing.T) {
 	require.False(t, ok)
 	require.Nil(t, val)
 
-	i := item{
-		key:      1,
-		conflict: 1,
-		value:    2,
+	i := Item{
+		Key:      1,
+		Conflict: 1,
+		Value:    2,
 	}
 	s.Set(&i)
 	val, ok = s.Get(1, 0)
@@ -151,10 +151,10 @@ func TestStoreCollision(t *testing.T) {
 func BenchmarkStoreGet(b *testing.B) {
 	s := newStore()
 	key, conflict := z.KeyToHash(1)
-	i := item{
-		key:      key,
-		conflict: conflict,
-		value:    1,
+	i := Item{
+		Key:      key,
+		Conflict: conflict,
+		Value:    1,
 	}
 	s.Set(&i)
 	b.SetBytes(1)
@@ -171,10 +171,10 @@ func BenchmarkStoreSet(b *testing.B) {
 	b.SetBytes(1)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			i := item{
-				key:      key,
-				conflict: conflict,
-				value:    1,
+			i := Item{
+				Key:      key,
+				Conflict: conflict,
+				Value:    1,
 			}
 			s.Set(&i)
 		}
@@ -184,19 +184,19 @@ func BenchmarkStoreSet(b *testing.B) {
 func BenchmarkStoreUpdate(b *testing.B) {
 	s := newStore()
 	key, conflict := z.KeyToHash(1)
-	i := item{
-		key:      key,
-		conflict: conflict,
-		value:    1,
+	i := Item{
+		Key:      key,
+		Conflict: conflict,
+		Value:    1,
 	}
 	s.Set(&i)
 	b.SetBytes(1)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			s.Update(&item{
-				key:      key,
-				conflict: conflict,
-				value:    2,
+			s.Update(&Item{
+				Key:      key,
+				Conflict: conflict,
+				Value:    2,
 			})
 		}
 	})

--- a/ttl.go
+++ b/ttl.go
@@ -114,7 +114,7 @@ func (m *expirationMap) del(key uint64, expiration time.Time) {
 // cleanup removes all the items in the bucket that was just completed. It deletes
 // those items from the store, and calls the onEvict function on those items.
 // This function is meant to be called periodically.
-func (m *expirationMap) cleanup(store store, policy policy, onEvict onEvictFunc) {
+func (m *expirationMap) cleanup(store store, policy policy, onEvict itemCallback) {
 	if m == nil {
 		return
 	}
@@ -137,7 +137,11 @@ func (m *expirationMap) cleanup(store store, policy policy, onEvict onEvictFunc)
 		_, value := store.Del(key, conflict)
 
 		if onEvict != nil {
-			onEvict(key, conflict, value, cost)
+			onEvict(&Item{Key: key,
+				Conflict: conflict,
+				Value:    value,
+				Cost:     cost,
+			})
 		}
 	}
 }


### PR DESCRIPTION
- Making Item public makes the onEvict and onReject function calls more readable.
- Adding onReject allows us to tightly track every Set that happens, so we can avoid memory leaks in manually allocated memory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/180)
<!-- Reviewable:end -->
