### PR TITLE
Add life expectancy histogram

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -320,6 +320,9 @@ func (c *Cache) processItems() {
 	numToKeep := 100000 // TODO: Make this configurable via options.
 
 	trackAdmission := func(key uint64) {
+		if c.Metrics == nil {
+			return
+		}
 		startTs[key] = time.Now()
 		if len(startTs) > numToKeep {
 			for k := range startTs {
@@ -442,7 +445,7 @@ type Metrics struct {
 	all [doNotUse][]*uint64
 
 	mu   sync.RWMutex
-	life *z.HistogramData
+	life *z.HistogramData // Tracks the life expectancy of a key.
 }
 
 func newMetrics() *Metrics {

--- a/z/histogram.go
+++ b/z/histogram.go
@@ -80,7 +80,7 @@ func (histogram *HistogramData) Update(value int64) {
 	}
 }
 
-// PrintHistogram prints the histogram data in a human-readable format.
+// String converts the histogram data into human-readable string.
 func (histogram *HistogramData) String() string {
 	if histogram == nil {
 		return ""

--- a/z/histogram.go
+++ b/z/histogram.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package z
 
 import (

--- a/z/histogram.go
+++ b/z/histogram.go
@@ -1,0 +1,99 @@
+package z
+
+import (
+	"fmt"
+	"math"
+)
+
+// Creates bounds for an histogram. The bounds are powers of two of the form
+// [2^min_exponent, ..., 2^max_exponent].
+func HistogramBounds(minExponent, maxExponent uint32) []float64 {
+	var bounds []float64
+	for i := minExponent; i <= maxExponent; i++ {
+		bounds = append(bounds, float64(int(1)<<i))
+	}
+	return bounds
+}
+
+// HistogramData stores the information needed to represent the sizes of the keys and values
+// as a histogram.
+type HistogramData struct {
+	Bounds         []float64
+	Count          int64
+	CountPerBucket []int64
+	Min            int64
+	Max            int64
+	Sum            int64
+}
+
+// NewHistogramData returns a new instance of HistogramData with properly initialized fields.
+func NewHistogramData(bounds []float64) *HistogramData {
+	return &HistogramData{
+		Bounds:         bounds,
+		CountPerBucket: make([]int64, len(bounds)+1),
+		Max:            0,
+		Min:            math.MaxInt64,
+	}
+}
+
+// Update changes the Min and Max fields if value is less than or greater than the current values.
+func (histogram *HistogramData) Update(value int64) {
+	if value > histogram.Max {
+		histogram.Max = value
+	}
+	if value < histogram.Min {
+		histogram.Min = value
+	}
+
+	histogram.Sum += value
+	histogram.Count++
+
+	for index := 0; index <= len(histogram.Bounds); index++ {
+		// Allocate value in the last buckets if we reached the end of the Bounds array.
+		if index == len(histogram.Bounds) {
+			histogram.CountPerBucket[index]++
+			break
+		}
+
+		if value < int64(histogram.Bounds[index]) {
+			histogram.CountPerBucket[index]++
+			break
+		}
+	}
+}
+
+// PrintHistogram prints the histogram data in a human-readable format.
+func (histogram *HistogramData) PrintHistogram() {
+	if histogram == nil {
+		return
+	}
+
+	fmt.Printf("Min value: %d\n", histogram.Min)
+	fmt.Printf("Max value: %d\n", histogram.Max)
+	fmt.Printf("Mean: %.2f\n", float64(histogram.Sum)/float64(histogram.Count))
+	fmt.Printf("%24s %9s\n", "Range", "Count")
+
+	numBounds := len(histogram.Bounds)
+	for index, count := range histogram.CountPerBucket {
+		if count == 0 {
+			continue
+		}
+
+		// The last bucket represents the bucket that contains the range from
+		// the last bound up to infinity so it's processed differently than the
+		// other buckets.
+		if index == len(histogram.CountPerBucket)-1 {
+			lowerBound := int(histogram.Bounds[numBounds-1])
+			fmt.Printf("[%10d, %10s) %9d\n", lowerBound, "infinity", count)
+			continue
+		}
+
+		upperBound := int(histogram.Bounds[index])
+		lowerBound := 0
+		if index > 0 {
+			lowerBound = int(histogram.Bounds[index-1])
+		}
+
+		fmt.Printf("[%10d, %10d) %9d\n", lowerBound, upperBound, count)
+	}
+}


### PR DESCRIPTION
If cache is too small, keys can enter and leave very quickly. This results in poor cache usage. Adding a life expectancy histogram to track a sample of keys from admission into cache to eviction. If we see too many keys getting evicted quickly, (along with miss ratio) that's a clear signal that cache size is too small. This would help a user tweak cache size better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/182)
<!-- Reviewable:end -->
