### PR TITLE
update comments to correctly reflect counter space usage

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -77,8 +77,11 @@ type Config struct {
 	// accuracy and subsequent hit ratios.
 	//
 	// For example, if you expect your cache to hold 1,000,000 items when full,
-	// NumCounters should be 10,000,000 (10x). Each counter takes up 4 bits, so
-	// keeping 10,000,000 counters would require 5MB of memory.
+	// NumCounters should be 10,000,000 (10x). Each counter takes up roughly
+	// 3 bytes (4 bits for each counter * 4 copies plus about a byte per
+	// counter for the bloom filter). Note that the number of counters is
+	// internally rounded up to the nearest power of 2, so the space usage
+	// may be a little larger than 3 bytes * NumCounters.
 	NumCounters int64
 	// MaxCost can be considered as the cache capacity, in whatever units you
 	// choose to use.


### PR DESCRIPTION
When using ristretto in our application, we noticed that the memory used per counter was much higher than the documentation suggested. This PR updates the comments in the config struct to accurately represent the space per counter (and matches our observations). 

Sources:
https://github.com/neena/ristretto/blob/29b4dd7a077785696ba5422081b3c301d4c1e5f1/sketch.go#L43-L62
https://github.com/neena/ristretto/blob/8f368f2f2ab3a54cbe62fb9772cd75ce55e07802/z/bbloom.go#L51-L75

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/189)
<!-- Reviewable:end -->
