### PR TITLE
Add ReadMemStats function

### DIFF
--- a/z/calloc.go
+++ b/z/calloc.go
@@ -10,9 +10,9 @@ func NumAllocBytes() int64 {
 	return atomic.LoadInt64(&numBytes)
 }
 
-// JEMallocStats is used to fetch JE Malloc Stats. The stats are fetched from
+// MemStats is used to fetch JE Malloc Stats. The stats are fetched from
 // the mallctl namespace http://jemalloc.net/jemalloc.3.html#mallctl_namespace.
-type JEMallocStats struct {
+type MemStats struct {
 	// Total number of bytes allocated by the application.
 	// http://jemalloc.net/jemalloc.3.html#stats.allocated
 	Allocated uint64

--- a/z/calloc.go
+++ b/z/calloc.go
@@ -28,7 +28,7 @@ type JEMallocStats struct {
 	// resident if they correspond to demand-zeroed virtual memory that has not
 	// yet been touched. This is a multiple of the page size, and is larger
 	// than stats.active.
-	//	http://jemalloc.net/jemalloc.3.html#stats.resident
+	// http://jemalloc.net/jemalloc.3.html#stats.resident
 	Resident uint64
 	// Total number of bytes in virtual memory mappings that were retained
 	// rather than being returned to the operating system via e.g. munmap(2) or

--- a/z/calloc.go
+++ b/z/calloc.go
@@ -9,3 +9,34 @@ var numBytes int64
 func NumAllocBytes() int64 {
 	return atomic.LoadInt64(&numBytes)
 }
+
+// JEMallocStats is used to fetch JE Malloc Stats. The stats are fetched from
+// the mallctl namespace http://jemalloc.net/jemalloc.3.html#mallctl_namespace.
+type JEMallocStats struct {
+	// Total number of bytes allocated by the application.
+	// http://jemalloc.net/jemalloc.3.html#stats.allocated
+	Allocated uint64
+	// Total number of bytes in active pages allocated by the application. This
+	// is a multiple of the page size, and greater than or equal to
+	// Allocated.
+	// http://jemalloc.net/jemalloc.3.html#stats.active
+	Active uint64
+	// Maximum number of bytes in physically resident data pages mapped by the
+	// allocator, comprising all pages dedicated to allocator metadata, pages
+	// backing active allocations, and unused dirty pages. This is a maximum
+	// rather than precise because pages may not actually be physically
+	// resident if they correspond to demand-zeroed virtual memory that has not
+	// yet been touched. This is a multiple of the page size, and is larger
+	// than stats.active.
+	//	http://jemalloc.net/jemalloc.3.html#stats.resident
+	Resident uint64
+	// Total number of bytes in virtual memory mappings that were retained
+	// rather than being returned to the operating system via e.g. munmap(2) or
+	// similar. Retained virtual memory is typically untouched, decommitted, or
+	// purged, so it has no strongly associated physical memory (see extent
+	// hooks http://jemalloc.net/jemalloc.3.html#arena.i.extent_hooks for
+	// details). Retained memory is excluded from mapped memory statistics,
+	// e.g. stats.mapped (http://jemalloc.net/jemalloc.3.html#stats.mapped).
+	// http://jemalloc.net/jemalloc.3.html#stats.retained
+	Retained uint64
+}

--- a/z/calloc_jemalloc.go
+++ b/z/calloc_jemalloc.go
@@ -80,6 +80,31 @@ func Free(b []byte) {
 	}
 }
 
+// ReadJEMallocStats populates stats with JE Malloc statistics.
+func ReadJEMallocStats(stats *JEMallocStats) {
+	if stats == nil {
+		panic("function argument should not be nil")
+	}
+	stats.Allocated = fetchStat("stats.allocated")
+	stats.Active = fetchStat("stats.active")
+	stats.Resident = fetchStat("stats.resident")
+	stats.Retained = fetchStat("stats.retained")
+}
+
+// fetchStat is used to read a specific attribute from je malloc stats using
+// mallctl.
+func fetchStat(s string) uint64 {
+	var out uint64
+	sz := unsafe.Sizeof(&out)
+	C.je_mallctl(
+		(C.CString)(s),                   // Query: eg: stats.allocated, stats.resident, etc.
+		unsafe.Pointer(&out),             // Variable to store the output.
+		(*C.size_t)(unsafe.Pointer(&sz)), // Size of the output variable.
+		nil,                              // Input variable used to set a value.
+		0)                                // Size of the input variable.
+	return out
+}
+
 func StatsPrint() {
 	opts := C.CString("mdablxe")
 	C.je_malloc_stats_print(nil, nil, opts)

--- a/z/calloc_jemalloc.go
+++ b/z/calloc_jemalloc.go
@@ -80,8 +80,8 @@ func Free(b []byte) {
 	}
 }
 
-// ReadJEMallocStats populates stats with JE Malloc statistics.
-func ReadJEMallocStats(stats *JEMallocStats) {
+// ReadMemStats populates stats with JE Malloc statistics.
+func ReadMemStats(stats *JEMallocStats) {
 	if stats == nil {
 		return
 	}

--- a/z/calloc_jemalloc.go
+++ b/z/calloc_jemalloc.go
@@ -83,7 +83,7 @@ func Free(b []byte) {
 // ReadJEMallocStats populates stats with JE Malloc statistics.
 func ReadJEMallocStats(stats *JEMallocStats) {
 	if stats == nil {
-		panic("function argument should not be nil")
+		return
 	}
 	stats.Allocated = fetchStat("stats.allocated")
 	stats.Active = fetchStat("stats.active")
@@ -91,8 +91,7 @@ func ReadJEMallocStats(stats *JEMallocStats) {
 	stats.Retained = fetchStat("stats.retained")
 }
 
-// fetchStat is used to read a specific attribute from je malloc stats using
-// mallctl.
+// fetchStat is used to read a specific attribute from je malloc stats using mallctl.
 func fetchStat(s string) uint64 {
 	var out uint64
 	sz := unsafe.Sizeof(&out)

--- a/z/calloc_nojemalloc.go
+++ b/z/calloc_nojemalloc.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 )
 
-// Provides versions of New and Free when cgo is not available (e.g. cross
-// compilation).
+// Provides versions of Calloc, CallocNoRef, etc when jemalloc is not available
+// (eg: build without jemalloc tag).
 
 // Calloc allocates a slice of size n.
 func Calloc(n int) []byte {
@@ -30,3 +30,7 @@ func Free(b []byte) {}
 func StatsPrint() {
 	fmt.Println("Using Go memory")
 }
+
+// ReadJEMallocStats doesn't do anything since all the memory is being managed
+// by the Go runtime.
+func ReadJEMallocStats(_ *JEMallocStats) { return }

--- a/z/calloc_nojemalloc.go
+++ b/z/calloc_nojemalloc.go
@@ -31,6 +31,6 @@ func StatsPrint() {
 	fmt.Println("Using Go memory")
 }
 
-// ReadJEMallocStats doesn't do anything since all the memory is being managed
+// ReadMemStats doesn't do anything since all the memory is being managed
 // by the Go runtime.
-func ReadJEMallocStats(_ *JEMallocStats) { return }
+func ReadMemStats(_ *MemStats) { return }


### PR DESCRIPTION
JE Malloc is used to manually allocate memory. This PR adds a `ReadMemStats` 
function (similar to runtime.ReadMemStats) that can be used to fetch JE Malloc statistics at runtime.

This PR  supports fetching `Allocated, Active, Retained, and Resident` memory information.

Fixes - DGRAPH-2382
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/193)
<!-- Reviewable:end -->
