### PR TITLE
Introduce Mmapped buffers and Merge Sort

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,7 @@ require (
 	github.com/cespare/xxhash v1.1.0
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
 	github.com/dustin/go-humanize v1.0.0
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.4.0
+	golang.org/x/sys v0.0.0-20200918174421-af09f7315aff
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczC
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
@@ -15,6 +17,8 @@ github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasO
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+golang.org/x/sys v0.0.0-20200918174421-af09f7315aff h1:1CPUrky56AcgSpxz/KfgzQWzfG09u5YOL8MvPYBlrL8=
+golang.org/x/sys v0.0.0-20200918174421-af09f7315aff/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/z/buffer.go
+++ b/z/buffer.go
@@ -394,6 +394,10 @@ func rawSlice(buf []byte) []byte {
 
 // Slice would return the slice written at offset.
 func (b *Buffer) Slice(offset int) ([]byte, int) {
+	if offset >= b.offset {
+		return nil, 0
+	}
+
 	sz := binary.BigEndian.Uint32(b.buf[offset:])
 	start := offset + 4
 	next := start + int(sz)

--- a/z/buffer_test.go
+++ b/z/buffer_test.go
@@ -18,6 +18,7 @@ package z
 
 import (
 	"bytes"
+	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -25,78 +26,101 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCallocBuffer(t *testing.T) {
+func TestBuffer(t *testing.T) {
 	rand.Seed(time.Now().Unix())
 
-	var bytesBuffer bytes.Buffer // This is just for verifying result.
-	bytesBuffer.Grow(512)
+	for btype := UseCalloc; btype < UseInvalid; btype++ {
+		name := fmt.Sprintf("Using mode %s", btype)
+		t.Run(name, func(t *testing.T) {
+			var bytesBuffer bytes.Buffer // This is just for verifying result.
+			bytesBuffer.Grow(512)
 
-	cBuffer := NewBuffer(512)
+			cBuffer, err := NewBuffer(512, 4<<30, btype)
+			require.Nil(t, err)
+			defer cBuffer.Release()
 
-	// Writer small []byte
-	var smallBytes [256]byte
-	rand.Read(smallBytes[:])
-	var bigBytes [1024]byte
-	rand.Read(bigBytes[:])
+			// Writer small []byte
+			var smallBytes [256]byte
+			rand.Read(smallBytes[:])
+			var bigBytes [1024]byte
+			rand.Read(bigBytes[:])
 
-	_, err := cBuffer.Write(smallBytes[:])
-	require.NoError(t, err, "unable to write data to page buffer")
-	_, err = cBuffer.Write(bigBytes[:])
-	require.NoError(t, err, "unable to write data to page buffer")
+			_, err = cBuffer.Write(smallBytes[:])
+			require.NoError(t, err, "unable to write data to page buffer")
+			_, err = cBuffer.Write(bigBytes[:])
+			require.NoError(t, err, "unable to write data to page buffer")
 
-	// Write data to bytesBuffer also, just to match result.
-	bytesBuffer.Write(smallBytes[:])
-	bytesBuffer.Write(bigBytes[:])
+			// Write data to bytesBuffer also, just to match result.
+			bytesBuffer.Write(smallBytes[:])
+			bytesBuffer.Write(bigBytes[:])
 
-	require.True(t, bytes.Equal(cBuffer.Bytes(), bytesBuffer.Bytes()))
-}
-
-func TestCallocBufferWrite(t *testing.T) {
-	rand.Seed(time.Now().Unix())
-
-	var wb [128]byte
-	rand.Read(wb[:])
-
-	cb := NewBuffer(32)
-	bb := new(bytes.Buffer)
-
-	end := 32
-	for i := 0; i < 3; i++ {
-		n, err := cb.Write(wb[:end])
-		require.NoError(t, err, "unable to write bytes to buffer")
-		require.Equal(t, n, end, "length of buffer and length written should be equal")
-
-		// append to bb also for testing.
-		bb.Write(wb[:end])
-
-		require.True(t, bytes.Equal(cb.Bytes(), bb.Bytes()), "Both bytes should match")
-		end = end * 2
+			require.True(t, bytes.Equal(cBuffer.Bytes(), bytesBuffer.Bytes()))
+		})
 	}
 }
 
-func TestSliceAlloc(t *testing.T) {
-	var buf Buffer
-	count := 10000
-	expectedSlice := make([][]byte, 0, count)
+func TestBufferWrite(t *testing.T) {
+	rand.Seed(time.Now().Unix())
 
-	// Create "count" number of slices.
-	for i := 0; i < count; i++ {
-		sz := rand.Intn(1000)
-		testBuf := make([]byte, sz)
-		rand.Read(testBuf)
+	for btype := UseCalloc; btype < UseInvalid; btype++ {
+		name := fmt.Sprintf("Using mode %s", btype)
+		t.Run(name, func(t *testing.T) {
+			var wb [128]byte
+			rand.Read(wb[:])
 
-		newSlice := buf.SliceAllocate(sz)
-		require.Equal(t, sz, copy(newSlice, testBuf))
+			cb, err := NewBuffer(32, 4<<30, btype)
+			require.Nil(t, err)
+			defer cb.Release()
 
-		// Save testBuf for verification.
-		expectedSlice = append(expectedSlice, testBuf)
+			bb := new(bytes.Buffer)
+
+			end := 32
+			for i := 0; i < 3; i++ {
+				n, err := cb.Write(wb[:end])
+				require.NoError(t, err, "unable to write bytes to buffer")
+				require.Equal(t, n, end, "length of buffer and length written should be equal")
+
+				// append to bb also for testing.
+				bb.Write(wb[:end])
+
+				require.True(t, bytes.Equal(cb.Bytes(), bb.Bytes()), "Both bytes should match")
+				end = end * 2
+			}
+		})
 	}
+}
 
-	offsets := buf.SliceOffsets(nil)
-	require.Equal(t, len(expectedSlice), len(offsets))
-	for i, off := range offsets {
-		// All the slices returned by the buffer should be equal to what we
-		// inserted earlier.
-		require.Equal(t, expectedSlice[i], buf.Slice(off))
+func TestBufferSlice(t *testing.T) {
+	for btype := UseCalloc; btype < UseInvalid; btype++ {
+		name := fmt.Sprintf("Using mode %s", btype)
+		t.Run(name, func(t *testing.T) {
+			buf, err := NewBuffer(0, 0, btype)
+			require.Nil(t, err)
+			defer buf.Release()
+
+			count := 10000
+			expectedSlice := make([][]byte, 0, count)
+
+			// Create "count" number of slices.
+			for i := 0; i < count; i++ {
+				sz := rand.Intn(1000)
+				testBuf := make([]byte, sz)
+				rand.Read(testBuf)
+
+				newSlice := buf.SliceAllocate(sz)
+				require.Equal(t, sz, copy(newSlice, testBuf))
+
+				// Save testBuf for verification.
+				expectedSlice = append(expectedSlice, testBuf)
+			}
+
+			offsets := buf.SliceOffsets(nil)
+			require.Equal(t, len(expectedSlice), len(offsets))
+			for i, off := range offsets {
+				// All the slices returned by the buffer should be equal to what we
+				// inserted earlier.
+				require.Equal(t, expectedSlice[i], buf.Slice(off))
+			}
+		})
 	}
 }

--- a/z/buffer_test.go
+++ b/z/buffer_test.go
@@ -113,9 +113,8 @@ func TestBufferSimpleSort(t *testing.T) {
 		if num < last {
 			fmt.Printf("num: %d idx: %d last: %d\n", num, i, last)
 		}
-		assert(num >= last)
 		i++
-		// require.GreaterOrEqual(t, num, last)
+		require.GreaterOrEqual(t, num, last)
 		last = num
 		// fmt.Printf("Got number: %d\n", num)
 	}

--- a/z/mmap.go
+++ b/z/mmap.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package z
+
+import (
+	"os"
+)
+
+// Mmap uses the mmap system call to memory-map a file. If writable is true,
+// memory protection of the pages is set so that they may be written to as well.
+func Mmap(fd *os.File, writable bool, size int64) ([]byte, error) {
+	return mmap(fd, writable, size)
+}
+
+// Munmap unmaps a previously mapped slice.
+func Munmap(b []byte) error {
+	return munmap(b)
+}
+
+// Madvise uses the madvise system call to give advise about the use of memory
+// when using a slice that is memory-mapped to a file. Set the readahead flag to
+// false if page references are expected in random order.
+func Madvise(b []byte, readahead bool) error {
+	return madvise(b, readahead)
+}

--- a/z/mmap_darwin.go
+++ b/z/mmap_darwin.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package z
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// Mmap uses the mmap system call to memory-map a file. If writable is true,
+// memory protection of the pages is set so that they may be written to as well.
+func mmap(fd *os.File, writable bool, size int64) ([]byte, error) {
+	mtype := unix.PROT_READ
+	if writable {
+		mtype |= unix.PROT_WRITE
+	}
+	return unix.Mmap(int(fd.Fd()), 0, int(size), mtype, unix.MAP_SHARED)
+}
+
+// Munmap unmaps a previously mapped slice.
+func munmap(b []byte) error {
+	return unix.Munmap(b)
+}
+
+// This is required because the unix package does not support the madvise system call on OS X.
+func madvise(b []byte, readahead bool) error {
+	advice := unix.MADV_NORMAL
+	if !readahead {
+		advice = unix.MADV_RANDOM
+	}
+
+	_, _, e1 := syscall.Syscall(syscall.SYS_MADVISE, uintptr(unsafe.Pointer(&b[0])),
+		uintptr(len(b)), uintptr(advice))
+	if e1 != 0 {
+		return e1
+	}
+	return nil
+}

--- a/z/mmap_plan9.go
+++ b/z/mmap_plan9.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package z
+
+import (
+	"os"
+	"syscall"
+)
+
+// Mmap uses the mmap system call to memory-map a file. If writable is true,
+// memory protection of the pages is set so that they may be written to as well.
+func mmap(fd *os.File, writable bool, size int64) ([]byte, error) {
+	return nil, syscall.EPLAN9
+}
+
+// Munmap unmaps a previously mapped slice.
+func munmap(b []byte) error {
+	return syscall.EPLAN9
+}
+
+// Madvise uses the madvise system call to give advise about the use of memory
+// when using a slice that is memory-mapped to a file. Set the readahead flag to
+// false if page references are expected in random order.
+func madvise(b []byte, readahead bool) error {
+	return syscall.EPLAN9
+}

--- a/z/mmap_unix.go
+++ b/z/mmap_unix.go
@@ -1,0 +1,51 @@
+// +build !windows,!darwin,!plan9
+
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package z
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// Mmap uses the mmap system call to memory-map a file. If writable is true,
+// memory protection of the pages is set so that they may be written to as well.
+func mmap(fd *os.File, writable bool, size int64) ([]byte, error) {
+	mtype := unix.PROT_READ
+	if writable {
+		mtype |= unix.PROT_WRITE
+	}
+	return unix.Mmap(int(fd.Fd()), 0, int(size), mtype, unix.MAP_SHARED)
+}
+
+// Munmap unmaps a previously mapped slice.
+func munmap(b []byte) error {
+	return unix.Munmap(b)
+}
+
+// Madvise uses the madvise system call to give advise about the use of memory
+// when using a slice that is memory-mapped to a file. Set the readahead flag to
+// false if page references are expected in random order.
+func madvise(b []byte, readahead bool) error {
+	flags := unix.MADV_NORMAL
+	if !readahead {
+		flags = unix.MADV_RANDOM
+	}
+	return unix.Madvise(b, flags)
+}

--- a/z/mmap_windows.go
+++ b/z/mmap_windows.go
@@ -1,0 +1,91 @@
+// +build windows
+
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package z
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func mmap(fd *os.File, write bool, size int64) ([]byte, error) {
+	protect := syscall.PAGE_READONLY
+	access := syscall.FILE_MAP_READ
+
+	if write {
+		protect = syscall.PAGE_READWRITE
+		access = syscall.FILE_MAP_WRITE
+	}
+	fi, err := fd.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	// In windows, we cannot mmap a file more than it's actual size.
+	// So truncate the file to the size of the mmap.
+	if fi.Size() < size {
+		if err := fd.Truncate(size); err != nil {
+			return nil, fmt.Errorf("truncate: %s", err)
+		}
+	}
+
+	// Open a file mapping handle.
+	sizelo := uint32(size >> 32)
+	sizehi := uint32(size) & 0xffffffff
+
+	handler, err := syscall.CreateFileMapping(syscall.Handle(fd.Fd()), nil,
+		uint32(protect), sizelo, sizehi, nil)
+	if err != nil {
+		return nil, os.NewSyscallError("CreateFileMapping", err)
+	}
+
+	// Create the memory map.
+	addr, err := syscall.MapViewOfFile(handler, uint32(access), 0, 0, uintptr(size))
+	if addr == 0 {
+		return nil, os.NewSyscallError("MapViewOfFile", err)
+	}
+
+	// Close mapping handle.
+	if err := syscall.CloseHandle(syscall.Handle(handler)); err != nil {
+		return nil, os.NewSyscallError("CloseHandle", err)
+	}
+
+	// Slice memory layout
+	// Copied this snippet from golang/sys package
+	var sl = struct {
+		addr uintptr
+		len  int
+		cap  int
+	}{addr, int(size), int(size)}
+
+	// Use unsafe to turn sl into a []byte.
+	data := *(*[]byte)(unsafe.Pointer(&sl))
+
+	return data, nil
+}
+
+func munmap(b []byte) error {
+	return syscall.UnmapViewOfFile(uintptr(unsafe.Pointer(&b[0])))
+}
+
+func madvise(b []byte, readahead bool) error {
+	// Do Nothing. We don’t care about this setting on Windows
+	return nil
+}


### PR DESCRIPTION
Buffers can now be mmapped as well as Calloc'd. This PR also copies over all the mmap files from Badger to allow mmap support in various platforms.

This PR also introduces Merge Sort to do sorting of the buffer using an extra temporary space costing half of the space as the original buffer, currently allocated on Calloc. We can't use quick sort. Each entry is variable length, so we can't just swap them in the buffer. Merge Sort allows us to iterate over them linearly, hence is a better fit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/194)
<!-- Reviewable:end -->
