### PR TITLE
Improve memory performance

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -68,6 +68,9 @@ type Cache struct {
 	stop chan struct{}
 	// cost calculates cost from a value.
 	cost func(value interface{}) int64
+	// ignoreInternalCost dictates whether to ignore the cost of internally storing
+	// the item in the cost calculation.
+	ignoreInternalCost bool
 	// cleanupTicker is used to periodically check for entries whose TTL has passed.
 	cleanupTicker *time.Ticker
 	// Metrics contains a running log of important statistics like hits, misses,
@@ -122,6 +125,11 @@ type Config struct {
 	// is ran after Set is called for a new item or an item update with a cost
 	// param of 0.
 	Cost func(value interface{}) int64
+	// IgnoreInternalCost set to true indicates to the cache that the cost of
+	// internally storing the value should be ignored. This is useful when the
+	// cost passed to set is not using bytes as units. Keep in mind that setting
+	// this to true will increase the memory usage.
+	IgnoreInternalCost bool
 }
 
 type itemFlag byte
@@ -155,14 +163,15 @@ func NewCache(config *Config) (*Cache, error) {
 	}
 	policy := newPolicy(config.NumCounters, config.MaxCost)
 	cache := &Cache{
-		store:         newStore(),
-		policy:        policy,
-		getBuf:        newRingBuffer(policy, config.BufferItems),
-		setBuf:        make(chan *Item, setBufSize),
-		keyToHash:     config.KeyToHash,
-		stop:          make(chan struct{}),
-		cost:          config.Cost,
-		cleanupTicker: time.NewTicker(time.Duration(bucketDurationSecs) * time.Second / 2),
+		store:              newStore(),
+		policy:             policy,
+		getBuf:             newRingBuffer(policy, config.BufferItems),
+		setBuf:             make(chan *Item, setBufSize),
+		keyToHash:          config.KeyToHash,
+		stop:               make(chan struct{}),
+		cost:               config.Cost,
+		ignoreInternalCost: config.IgnoreInternalCost,
+		cleanupTicker:      time.NewTicker(time.Duration(bucketDurationSecs) * time.Second / 2),
 	}
 	cache.onExit = func(val interface{}) {
 		if config.OnExit != nil && val != nil {
@@ -396,8 +405,10 @@ func (c *Cache) processItems() {
 			if i.Cost == 0 && c.cost != nil && i.flag != itemDelete {
 				i.Cost = c.cost(i.Value)
 			}
-			// Add the cost of internally storing the object.
-			i.Cost += itemSize
+			if !c.ignoreInternalCost {
+				// Add the cost of internally storing the object.
+				i.Cost += itemSize
+			}
 
 			switch i.flag {
 			case itemNew:

--- a/stress_test.go
+++ b/stress_test.go
@@ -15,10 +15,11 @@ import (
 
 func TestStressSetGet(t *testing.T) {
 	c, err := NewCache(&Config{
-		NumCounters: 1000,
-		MaxCost:     100,
-		BufferItems: 64,
-		Metrics:     true,
+		NumCounters:        1000,
+		MaxCost:            100,
+		IgnoreInternalCost: true,
+		BufferItems:        64,
+		Metrics:            true,
 	})
 	require.NoError(t, err)
 

--- a/ttl.go
+++ b/ttl.go
@@ -26,11 +26,11 @@ var (
 	bucketDurationSecs = int64(5)
 )
 
-func storageBucket(t time.Time) int64 {
-	return (t.Unix() / bucketDurationSecs) + 1
+func storageBucket(t int64) int64 {
+	return (t / bucketDurationSecs) + 1
 }
 
-func cleanupBucket(t time.Time) int64 {
+func cleanupBucket(t int64) int64 {
 	// The bucket to cleanup is always behind the storage bucket by one so that
 	// no elements in that bucket (which might not have expired yet) are deleted.
 	return storageBucket(t) - 1
@@ -51,13 +51,13 @@ func newExpirationMap() *expirationMap {
 	}
 }
 
-func (m *expirationMap) add(key, conflict uint64, expiration time.Time) {
+func (m *expirationMap) add(key, conflict uint64, expiration int64) {
 	if m == nil {
 		return
 	}
 
 	// Items that don't expire don't need to be in the expiration map.
-	if expiration.IsZero() {
+	if expiration == 0 {
 		return
 	}
 
@@ -73,7 +73,7 @@ func (m *expirationMap) add(key, conflict uint64, expiration time.Time) {
 	b[key] = conflict
 }
 
-func (m *expirationMap) update(key, conflict uint64, oldExpTime, newExpTime time.Time) {
+func (m *expirationMap) update(key, conflict uint64, oldExpTime, newExpTime int64) {
 	if m == nil {
 		return
 	}
@@ -96,7 +96,7 @@ func (m *expirationMap) update(key, conflict uint64, oldExpTime, newExpTime time
 	newBucket[key] = conflict
 }
 
-func (m *expirationMap) del(key uint64, expiration time.Time) {
+func (m *expirationMap) del(key uint64, expiration int64) {
 	if m == nil {
 		return
 	}
@@ -120,7 +120,7 @@ func (m *expirationMap) cleanup(store store, policy policy, onEvict itemCallback
 	}
 
 	m.Lock()
-	now := time.Now()
+	now := time.Now().Unix()
 	bucketNum := cleanupBucket(now)
 	keys := m.buckets[bucketNum]
 	delete(m.buckets, bucketNum)
@@ -128,7 +128,7 @@ func (m *expirationMap) cleanup(store store, policy policy, onEvict itemCallback
 
 	for key, conflict := range keys {
 		// Sanity check. Verify that the store agrees that this key is expired.
-		if store.Expiration(key).After(now) {
+		if store.Expiration(key) > now {
 			continue
 		}
 


### PR DESCRIPTION
- Use an int64 instead of a time.Time struct to represent the time.
- By default, include the cost of the storeItem in the cost calculation.

Related to DGRAPH-1378

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/195)
<!-- Reviewable:end -->
