### PR TITLE
z: Add TotalSize method on bloom filter

### DIFF
--- a/z/bbloom.go
+++ b/z/bbloom.go
@@ -131,6 +131,11 @@ func (bl *Bloom) AddIfNotHas(hash uint64) bool {
 	return true
 }
 
+// TotalSize returns the total size of the bloom filter.
+func (bl *Bloom) TotalSize() uint64 {
+	return uint64(len(bl.bitset)*8) + 5*8
+}
+
 // Size makes Bloom filter with as bitset of size sz.
 func (bl *Bloom) Size(sz uint64) {
 	bl.bitset = make([]uint64, sz>>6)

--- a/z/bbloom.go
+++ b/z/bbloom.go
@@ -132,8 +132,8 @@ func (bl *Bloom) AddIfNotHas(hash uint64) bool {
 }
 
 // TotalSize returns the total size of the bloom filter.
-func (bl *Bloom) TotalSize() uint64 {
-	return uint64(len(bl.bitset)*8) + 5*8
+func (bl *Bloom) TotalSize() int {
+	return len(bl.bitset)*8 + 5*8
 }
 
 // Size makes Bloom filter with as bitset of size sz.

--- a/z/bbloom.go
+++ b/z/bbloom.go
@@ -133,6 +133,8 @@ func (bl *Bloom) AddIfNotHas(hash uint64) bool {
 
 // TotalSize returns the total size of the bloom filter.
 func (bl *Bloom) TotalSize() int {
+	// The bl struct has 5 members and each one is 8 byte. The bitset is a
+	// uint64 byte slice.
 	return len(bl.bitset)*8 + 5*8
 }
 


### PR DESCRIPTION
This PR adds a `TotalSize` function which returns the total size of the bloom filter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/197)
<!-- Reviewable:end -->
