### PR TITLE
Buffer: Use 256GB mmap size instead of MaxInt64

### DIFF
--- a/z/buffer.go
+++ b/z/buffer.go
@@ -70,7 +70,7 @@ const smallBufferSize = 64
 
 // Newbuffer is a helper utility, which creates a virtually unlimited Buffer in UseCalloc mode.
 func NewBuffer(sz int) *Buffer {
-	buf, err := NewBufferWith(sz, math.MaxInt64, UseCalloc)
+	buf, err := NewBufferWith(sz, math.MaxInt32, UseCalloc)
 	if err != nil {
 		log.Fatalf("while creating buffer: %v", err)
 	}
@@ -265,11 +265,13 @@ func (s *sortHelper) sortSmall(start, end int) {
 
 func assert(b bool) {
 	if !b {
-		log.Fatalf("Assertion failure")
+		log.Fatalf("%+v", errors.Errorf("Assertion failure"))
 	}
 }
 func check(err error) {
-	assert(err == nil)
+	if err != nil {
+		log.Fatalf("%+v", err)
+	}
 }
 func check2(_ interface{}, err error) {
 	check(err)

--- a/z/buffer.go
+++ b/z/buffer.go
@@ -70,7 +70,7 @@ const smallBufferSize = 64
 
 // Newbuffer is a helper utility, which creates a virtually unlimited Buffer in UseCalloc mode.
 func NewBuffer(sz int) *Buffer {
-	buf, err := NewBufferWith(sz, 100*math.MaxInt32, UseCalloc)
+	buf, err := NewBufferWith(sz, 256<<30, UseCalloc)
 	if err != nil {
 		log.Fatalf("while creating buffer: %v", err)
 	}

--- a/z/buffer.go
+++ b/z/buffer.go
@@ -70,7 +70,7 @@ const smallBufferSize = 64
 
 // Newbuffer is a helper utility, which creates a virtually unlimited Buffer in UseCalloc mode.
 func NewBuffer(sz int) *Buffer {
-	buf, err := NewBufferWith(sz, math.MaxInt32, UseCalloc)
+	buf, err := NewBufferWith(sz, 100*math.MaxInt32, UseCalloc)
 	if err != nil {
 		log.Fatalf("while creating buffer: %v", err)
 	}


### PR DESCRIPTION
MaxInt64 is 9.2 Exabyte and the test fails with `cannot allocate memory` on my computer.
This PR also fixes the build (it is failing on master).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/198)
<!-- Reviewable:end -->
