### PR TITLE
Public methods must not panic after Close()

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -147,6 +147,47 @@ func TestMultipleClose(t *testing.T) {
 	c.Close()
 }
 
+func TestSetAfterClose(t *testing.T) {
+	c, err := newTestCache()
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	c.Close()
+	require.False(t, c.Set(1, 1, 1))
+}
+
+func TestClearAfterClose(t *testing.T) {
+	c, err := newTestCache()
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	c.Close()
+	c.Clear()
+}
+
+func TestGetAfterClose(t *testing.T) {
+	c, err := newTestCache()
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	require.True(t, c.Set(1, 1, 1))
+	c.Close()
+
+	_, ok := c.Get(1)
+	require.False(t, ok)
+}
+
+func TestDelAfterClose(t *testing.T) {
+	c, err := newTestCache()
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	require.True(t, c.Set(1, 1, 1))
+	c.Close()
+
+	c.Del(1)
+}
+
 func TestCacheProcessItems(t *testing.T) {
 	m := &sync.Mutex{}
 	evicted := make(map[uint64]struct{})
@@ -788,4 +829,13 @@ func TestRistrettoCallocTTL(t *testing.T) {
 	wg.Wait()
 	time.Sleep(5 * time.Second)
 	require.Zero(t, z.NumAllocBytes())
+}
+
+func newTestCache() (*Cache, error) {
+	return NewCache(&Config{
+		NumCounters: 100,
+		MaxCost:     10,
+		BufferItems: 64,
+		Metrics:     true,
+	})
 }

--- a/policy.go
+++ b/policy.go
@@ -63,11 +63,12 @@ func newPolicy(numCounters, maxCost int64) policy {
 
 type defaultPolicy struct {
 	sync.Mutex
-	admit   *tinyLFU
-	evict   *sampledLFU
-	itemsCh chan []uint64
-	stop    chan struct{}
-	metrics *Metrics
+	admit    *tinyLFU
+	evict    *sampledLFU
+	itemsCh  chan []uint64
+	stop     chan struct{}
+	isClosed bool
+	metrics  *Metrics
 }
 
 func newDefaultPolicy(numCounters, maxCost int64) *defaultPolicy {
@@ -105,9 +106,14 @@ func (p *defaultPolicy) processItems() {
 }
 
 func (p *defaultPolicy) Push(keys []uint64) bool {
+	if p.isClosed {
+		return false
+	}
+
 	if len(keys) == 0 {
 		return true
 	}
+
 	select {
 	case p.itemsCh <- keys:
 		p.metrics.add(keepGets, keys[0], uint64(len(keys)))
@@ -241,10 +247,15 @@ func (p *defaultPolicy) Clear() {
 }
 
 func (p *defaultPolicy) Close() {
+	if p.isClosed {
+		return
+	}
+
 	// Block until the p.processItems goroutine returns.
 	p.stop <- struct{}{}
 	close(p.stop)
 	close(p.itemsCh)
+	p.isClosed = true
 }
 
 // sampledLFU is an eviction helper storing key-cost pairs.

--- a/policy_test.go
+++ b/policy_test.go
@@ -141,6 +141,18 @@ func TestPolicyClose(t *testing.T) {
 	p.itemsCh <- []uint64{1}
 }
 
+func TestPushAfterClose(t *testing.T) {
+	p := newDefaultPolicy(100, 10)
+	p.Close()
+	require.False(t, p.Push([]uint64{1, 2}))
+}
+
+func TestAddAfterClose(t *testing.T) {
+	p := newDefaultPolicy(100, 10)
+	p.Close()
+	p.Add(1, 1)
+}
+
 func TestSampledLFUAdd(t *testing.T) {
 	e := newSampledLFU(4)
 	e.add(1, 1)


### PR DESCRIPTION
The process crashes when callsites have many goroutines calling public methods after `Close()` was already called.
That must be handled gracefully.

```
panic: send on closed channel

goroutine 24430 [running]:
{path_redacted}/vendor/github.com/dgraph-io/ristretto.(*defaultPolicy).Push(0xc000676060, 0xc1417ed200, 0x40, 0x40, 0x3)
	{path_redacted}/vendor/github.com/dgraph-io/ristretto/policy.go:112 +0x64
{path_redacted}/vendor/github.com/dgraph-io/ristretto.(*ringStripe).Push(0xc14a61b2c0, 0xebbce095e9cac6f6)
	{path_redacted}/vendor/github.com/dgraph-io/ristretto/ring.go:51 +0x95
{path_redacted}/vendor/github.com/dgraph-io/ristretto.(*ringBuffer).Push(0xc00000e138, 0xebbce095e9cac6f6)
	{path_redacted}/vendor/github.com/dgraph-io/ristretto/ring.go:89 +0x60
{path_redacted}/vendor/github.com/dgraph-io/ristretto.(*Cache).Get(0xc0004fcf60, 0x14f8320, 0xc155a21d28, 0xbff0000000000000, 0x0, 0x0)
	{path_redacted}/vendor/github.com/dgraph-io/ristretto/cache.go:167 +0x8e
```

```
panic: send on closed channel

goroutine 23589 [running]:
{path_redacted}/vendor/github.com/dgraph-io/ristretto.(*Cache).Set(0xc0005ab800, 0x14d46a0, 0xc055784c00, 0x1643ee0, 0xc18eb74300, 0x1, 0xc16250bc00)
	{path_redacted}/vendor/github.com/dgraph-io/ristretto/cache.go:205 +0x12b
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/202)
<!-- Reviewable:end -->
