### PR TITLE
add mmaped b+ tree

### DIFF
--- a/z/btree.go
+++ b/z/btree.go
@@ -284,7 +284,7 @@ func (n node) isFull() bool {
 func (n node) search(k uint64) int {
 	N := n.numKeys()
 	lo, hi := 0, N
-	for hi-lo > 64 {
+	for hi-lo > 32 {
 		// 65/2 = 32
 		// lo = 33
 		// hi = 65
@@ -298,7 +298,7 @@ func (n node) search(k uint64) int {
 			lo = mid + 1
 		} else {
 			// else move left.
-			hi = mid - 1
+			hi = mid
 		}
 	}
 	// if N >= 256 {

--- a/z/btree.go
+++ b/z/btree.go
@@ -22,11 +22,14 @@ type Tree struct {
 
 // NewTree returns a memory mapped B+ tree.
 func NewTree(mf *MmapFile) *Tree {
+	// Tell kernel that we'd be reading pages in random order, so don't do read ahead.
+	check(Madvise(mf.Data, false))
 	t := &Tree{
 		mf:       mf,
 		nextPage: 1,
 	}
 	t.newNode(0)
+
 	// This acts as the rightmost pointer (all the keys are <= this key).
 	// This is necessary for B+ tree property that, all leaf nodes should
 	// be at same level.

--- a/z/btree.go
+++ b/z/btree.go
@@ -26,6 +26,10 @@ func NewTree(mf *MmapFile) *Tree {
 		nextPage: 1,
 	}
 	t.newNode(0)
+	// This acts as the rightmost pointer (all the keys are <= this key).
+	// This is necessary for B+ tree property that, all leaf nodes should
+	// be at same level.
+	t.Set(math.MaxUint64-1, 0)
 	return t
 }
 
@@ -312,11 +316,13 @@ func (n node) compact() int {
 	assert(n.isLeaf())
 	var left, right int
 	for right < maxKeys {
-		if n.key(right) == 0 {
+		k, v := n.key(right), n.val(right)
+		if k == 0 {
 			break
 		}
 		// If the value is non-zero, move the kv to right.
-		if n.val(right) != 0 {
+		// TODO(naman): Add test for second condition.
+		if v != 0 || k == math.MaxUint64-1 {
 			if left != right {
 				copy(n.data(left), n.data(right))
 			}

--- a/z/btree.go
+++ b/z/btree.go
@@ -3,59 +3,160 @@ package z
 import (
 	"encoding/binary"
 	"os"
+	"sort"
 )
 
 var pageSize = os.Getpagesize()
-var bf = pageSize / 16
+var maxKeys = (pageSize / 16) - 1
+
+type Tree struct {
+	mf       *MmapFile
+	nextPage uint64
+}
+
+func (t *Tree) newPage() uint64 {
+	offset := int(t.nextPage) * pageSize
+	t.nextPage++
+	n := node(t.mf.Data[offset : offset+pageSize])
+	n.setBit(bitUsed)
+	return t.nextPage - 1
+}
+func (t *Tree) node(pid uint64) node {
+	start := pageSize * int(pid)
+	return node(t.mf.Data[start : start+pageSize])
+}
+
+// For internal nodes, they contain <key, ptr>.
+// where all entries <= key are stored in the corresponding ptr.
+func (t *Tree) set(n node, k, v uint64) {
+	if n.isLeaf() {
+		if n.isFull() {
+			// TODO: Split.
+		}
+		n.set(k, v)
+		return
+	}
+	// This is an internal node.
+	idx := n.search(k)
+	if idx >= maxKeys {
+		// We can just upgrade the key at maxKeys-1, so all key-values under k
+		// would get stored in the same child.
+		n.setAt(keyOffset(maxKeys-1), k)
+		idx = maxKeys - 1
+	}
+	if n.key(idx) == 0 {
+		n.setAt(keyOffset(idx), k)
+	}
+	child := t.node(n.uint64(valOffset(idx)))
+	t.set(child, k, v)
+}
+
+func (t *Tree) Set(k, v uint64) {
+	n := t.node(0)
+	for !n.isLeaf() {
+
+	}
+}
+
+func (t *Tree) split(n node) {
+	if !n.isFull() {
+		return
+	}
+	rightHalf := n[keyOffset(maxKeys/2):keyOffset(maxKeys)]
+
+	// Create a new node nn, copy over half the keys from n, and set the parent to n's parent.
+	ni := t.newPage()
+	nn := t.node(ni)
+	copy(nn, rightHalf)
+	nn.setAt(keyOffset(maxKeys), ni)
+
+	// Remove entries from node n.
+	ZeroOut(rightHalf, 0, len(rightHalf))
+
+	// Add nn in the common parent.
+	// p := t.node(n.parent())
+	// p.set(nn.key(0), uint64(ni))
+
+	// t.split(p) //
+}
 
 // Each node in the node is of size pageSize. Two kinds of nodes. Leaf nodes and internal nodes.
 // Leaf nodes only contain the data. Internal nodes would contain the key and the offset to the child node.
 // Internal node would have first entry as
 // <0 offset to child>, <1000 offset>, <5000 offset>, and so on...
 // Leaf nodes would just have: <key, value>, <key, value>, and so on...
+// Last 16 bytes of the node are off limits.
 type node []byte
 
-func (n node) keyAt(i int) uint64 {
-	return binary.BigEndian.Uint64(n[16*i : 16*i+8])
+func (n node) uint64(start int) uint64 {
+	return binary.BigEndian.Uint64(n[start : start+8])
 }
 
-func (n node) setAt(i int, k, v uint64) {
-	start := 16 * i
+func keyOffset(i int) int       { return 16 * i }   // Last 16 bytes are kept off limits.
+func valOffset(i int) int       { return 16*i + 8 } // Last 16 bytes are kept off limits.
+func (n node) key(i int) uint64 { return n.uint64(keyOffset(i)) }
+func (n node) id() uint64       { return n.key(maxKeys) }
+
+func (n node) next(k uint64) node {
+	return nil
+}
+func (n node) setAt(start int, k uint64) {
 	binary.BigEndian.PutUint64(n[start:start+8], k)
-	binary.BigEndian.PutUint64(n[start+8:start+16], v)
 }
-
 func (n node) moveRight(i int) {
-	start := 16 * i
+	start := keyOffset(i)
 	copy(n[start+16:], n[start:])
 	// TODO: maybe we can optimize this to avoid moving the entries which are already zero.
 }
 
-// isFull checks that the node is already full.
-func (n node) isFull() bool {
-	return n.keyAt(bf-1) > 0
+const (
+	bitUsed = iota
+	bitInternal
+	bitLeaf
+)
+
+func (n node) setBit(b int) {
+	vo := valOffset(maxKeys)
+	v := n.uint64(vo)
+	n.setAt(vo, v|(1<<bitInternal))
 }
 
-func (n node) Set(k, v uint64) {
-	for i := 0; i < bf; i++ {
-		ks := n.keyAt(i)
+func (n node) isLeaf() bool {
+	return n.uint64(valOffset(maxKeys))&bitLeaf > 0
+}
+
+// isFull checks that the node is already full.
+func (n node) isFull() bool {
+	return n.key(maxKeys-1) > 0
+}
+func (n node) search(k uint64) int {
+	return sort.Search(maxKeys, func(i int) bool {
+		// ks := n.keyAt(i + 1)
+		ks := n.key(i)
 		if ks == 0 {
-			n.setAt(i, k, v)
-			return
+			return true
 		}
-		if k > ks {
-			continue
-		} else if k == ks {
-			n.setAt(i, k, v)
-			return
-		}
-		if n.isFull() {
-			// TODO: Split this node into two.
-		}
-		// Found the first entry which is greater than k. So, we need to fit k just before it. For
-		// that, we should move the rest of the data in the node to the right to make space for k.
-		n.moveRight(i)
-		n.setAt(i, k, v)
+		return ks >= k
+	})
+}
+func (n node) set(k, v uint64) {
+	idx := n.search(k)
+	if idx >= maxKeys {
 		return
 	}
+	ki := n.key(idx)
+	if ki == 0 || ki == k {
+		n.setAt(valOffset(idx), v)
+		return
+	}
+	if ki > k {
+		// Found the first entry which is greater than k. So, we need to fit k
+		// just before it. For that, we should move the rest of the data in the
+		// node to the right to make space for k.
+		n.moveRight(idx)
+		n.setAt(keyOffset(idx), k)
+		n.setAt(valOffset(idx), v)
+		return
+	}
+	panic("shouldn't reach here")
 }

--- a/z/btree.go
+++ b/z/btree.go
@@ -283,23 +283,35 @@ func (n node) isFull() bool {
 }
 func (n node) search(k uint64) int {
 	N := n.numKeys()
-	linear := func() int {
-		for i := 0; i < N; i++ {
-			if ki := n.key(i); ki >= k {
-				return i
-			}
+	lo, hi := 0, N
+	for hi-lo > 64 {
+		// 65/2 = 32
+		// lo = 33
+		// hi = 65
+		mid := (hi + lo) / 2
+		km := n.key(mid)
+		if k == km {
+			return mid
 		}
-		return N
+		if k > km {
+			// key is greater than the key at mid, so move right.
+			lo = mid + 1
+		} else {
+			// else move left.
+			hi = mid - 1
+		}
 	}
-	// binary := func() int {
+	// if N >= 256 {
 	// 	return sort.Search(N, func(i int) bool {
 	// 		return n.key(i) >= k
 	// 	})
 	// }
-	// if N >= 128 {
-	// 	return binary()
-	// }
-	return linear()
+	for i := lo; i <= hi; i++ {
+		if ki := n.key(i); ki >= k {
+			return i
+		}
+	}
+	return N
 }
 func (n node) maxKey() uint64 {
 	idx := n.numKeys()

--- a/z/btree.go
+++ b/z/btree.go
@@ -124,7 +124,7 @@ func (t *Tree) get(n node, k uint64) uint64 {
 	}
 	// This is internal node
 	idx := n.search(k)
-	if idx == maxKeys || n.key(idx) == 0 {
+	if idx == n.numKeys() || n.key(idx) == 0 {
 		return 0
 	}
 	child := t.node(n.uint64(valOffset(idx)))
@@ -278,20 +278,21 @@ func (n node) isFull() bool {
 	return n.numKeys() == maxKeys
 }
 func (n node) search(k uint64) int {
+	N := n.numKeys()
 	linear := func() int {
-		for i := 0; i < maxKeys; i++ {
-			if ki := n.key(i); ki == 0 || ki >= k {
+		for i := 0; i < N; i++ {
+			if ki := n.key(i); ki >= k {
 				return i
 			}
 		}
-		return maxKeys
+		return N
 	}
 	// binary := func() int {
-	// 	return sort.Search(n.numKeys(), func(i int) bool {
+	// 	return sort.Search(N, func(i int) bool {
 	// 		return n.key(i) >= k
 	// 	})
 	// }
-	// if n.numKeys() >= 128 {
+	// if N >= 128 {
 	// 	return binary()
 	// }
 	return linear()
@@ -332,7 +333,7 @@ func (n node) compact() int {
 func (n node) get(k uint64) uint64 {
 	idx := n.search(k)
 	// key is not found
-	if idx == maxKeys {
+	if idx == n.numKeys() {
 		return 0
 	}
 	if ki := n.key(idx); ki == k {

--- a/z/btree.go
+++ b/z/btree.go
@@ -20,7 +20,7 @@ type Tree struct {
 }
 
 // NewTree returns a memory mapped B+ tree
-func NewTree(mf *MmapFile, pageSize int) *Tree {
+func NewTree(mf *MmapFile) *Tree {
 	t := &Tree{
 		mf:       mf,
 		nextPage: 1,
@@ -275,7 +275,7 @@ func (n node) isLeaf() bool {
 
 // isFull checks that the node is already full.
 func (n node) isFull() bool {
-	return n.key(maxKeys-1) > 0
+	return n.numKeys() == maxKeys
 }
 func (n node) search(k uint64) int {
 	linear := func() int {

--- a/z/btree.go
+++ b/z/btree.go
@@ -1,0 +1,61 @@
+package z
+
+import (
+	"encoding/binary"
+	"os"
+)
+
+var pageSize = os.Getpagesize()
+var bf = pageSize / 16
+
+// Each node in the node is of size pageSize. Two kinds of nodes. Leaf nodes and internal nodes.
+// Leaf nodes only contain the data. Internal nodes would contain the key and the offset to the child node.
+// Internal node would have first entry as
+// <0 offset to child>, <1000 offset>, <5000 offset>, and so on...
+// Leaf nodes would just have: <key, value>, <key, value>, and so on...
+type node []byte
+
+func (n node) keyAt(i int) uint64 {
+	return binary.BigEndian.Uint64(n[16*i : 16*i+8])
+}
+
+func (n node) setAt(i int, k, v uint64) {
+	start := 16 * i
+	binary.BigEndian.PutUint64(n[start:start+8], k)
+	binary.BigEndian.PutUint64(n[start+8:start+16], v)
+}
+
+func (n node) moveRight(i int) {
+	start := 16 * i
+	copy(n[start+16:], n[start:])
+	// TODO: maybe we can optimize this to avoid moving the entries which are already zero.
+}
+
+// isFull checks that the node is already full.
+func (n node) isFull() bool {
+	return n.keyAt(bf-1) > 0
+}
+
+func (n node) Set(k, v uint64) {
+	for i := 0; i < bf; i++ {
+		ks := n.keyAt(i)
+		if ks == 0 {
+			n.setAt(i, k, v)
+			return
+		}
+		if k > ks {
+			continue
+		} else if k == ks {
+			n.setAt(i, k, v)
+			return
+		}
+		if n.isFull() {
+			// TODO: Split this node into two.
+		}
+		// Found the first entry which is greater than k. So, we need to fit k just before it. For
+		// that, we should move the rest of the data in the node to the right to make space for k.
+		n.moveRight(i)
+		n.setAt(i, k, v)
+		return
+	}
+}

--- a/z/btree.go
+++ b/z/btree.go
@@ -231,6 +231,7 @@ func (n node) moveRight(lo int, maxKeys int) {
 	if hi == maxKeys {
 		panic("endIdx == maxKeys")
 	}
+	// lo+1 is on the right. And copying is also left to right. So, you'll overwrite the contents.
 	copy(n[keyOffset(lo+1):keyOffset(hi+1)], n[keyOffset(lo):keyOffset(hi)])
 }
 

--- a/z/btree.go
+++ b/z/btree.go
@@ -4,76 +4,69 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
-	"os"
 	"sort"
 	"strings"
 )
 
-var pageSize = os.Getpagesize()
-var maxKeys = (pageSize / 16) - 1
-
+// Tree represents the structure for mmaped B+ tree
 type Tree struct {
+	pageSize int
+	maxKeys  int
 	mf       *MmapFile
 	nextPage uint64
 }
 
-func NewTree(mf *MmapFile, numRanges int) *Tree {
+// NewTree returns a memory mapped B+ tree
+func NewTree(mf *MmapFile, pageSize int) *Tree {
 	t := &Tree{
+		pageSize: pageSize,
+		maxKeys:  (pageSize / 16) - 1,
 		mf:       mf,
 		nextPage: 1,
 	}
 	t.newNode(0)
-	t.Set(math.MaxUint64-1, 0)
-	// if numRanges > 0 {
-	// 	jump := uint64(math.MaxUint64) / uint64(numRanges)
-	// 	fmt.Printf("jump = %d\n", jump)
-	// 	start := jump
-	// 	for i := 0; i < numRanges; i++ {
-	// 		t.Set(start, 0)
-	// 		start += jump
-	// 	}
-	// }
 	return t
 }
 
 func (t *Tree) newNode(bit uint64) node {
-	offset := int(t.nextPage) * pageSize
+	offset := int(t.nextPage) * t.pageSize
 	t.nextPage++
-	n := node(t.mf.Data[offset : offset+pageSize])
+	n := node(t.mf.Data[offset : offset+t.pageSize])
 	ZeroOut(n, 0, len(n))
-	n.setBit(bitUsed | bit)
-	n.setAt(keyOffset(maxKeys), t.nextPage-1)
-	// fmt.Printf("Created page of id: %d at offset: %d\n", n.pageId(), offset)
+	n.setBit(bitUsed|bit, t.maxKeys)
+	n.setAt(keyOffset(t.maxKeys), t.nextPage-1)
 	return n
 }
 func (t *Tree) node(pid uint64) node {
 	if pid == 0 {
 		return nil
 	}
-	start := pageSize * int(pid)
-	return node(t.mf.Data[start : start+pageSize])
+	start := t.pageSize * int(pid)
+	return node(t.mf.Data[start : start+t.pageSize])
 }
 
+// Set sets the key-value pair in the tree
 func (t *Tree) Set(k, v uint64) {
 	if k == math.MaxUint64 {
 		panic("Does not support setting MaxUint64")
 	}
 	root := t.node(1)
 	t.set(root, k, v)
-	if root.isFull() {
+	if root.isFull(t.maxKeys) {
 		right := t.split(root)
-		left := t.newNode(root.bits())
-		copy(left[:keyOffset(maxKeys)], root)
+		left := t.newNode(root.bits(t.maxKeys))
+		copy(left[:keyOffset(t.maxKeys)], root)
 
-		part := root[:keyOffset(maxKeys)]
+		part := root[:keyOffset(t.maxKeys)]
 		ZeroOut(part, 0, len(part))
 
-		root.set(left.maxKey(), left.pageId())
-		root.set(right.maxKey(), right.pageId())
+		root.set(left.maxKey(t.maxKeys), left.pageID(t.maxKeys), t.maxKeys)
+		root.set(right.maxKey(t.maxKeys), right.pageID(t.maxKeys), t.maxKeys)
 	}
 }
 
-// Get returns the corresponding value, else math.MaxUint64 if key is not found
+// Get looks for key and returns the corresponding value.
+// If key is not found, 0 is returned.
 func (t *Tree) Get(k uint64) uint64 {
 	if k == math.MaxUint64 {
 		panic("Does not support getting MaxUint64")
@@ -83,12 +76,12 @@ func (t *Tree) Get(k uint64) uint64 {
 }
 
 func (t *Tree) get(n node, k uint64) uint64 {
-	if n.isLeaf() {
-		return n.get(k)
+	if n.isLeaf(t.maxKeys) {
+		return n.get(k, t.maxKeys)
 	}
 	// This is internal node
-	idx := n.search(k)
-	if idx == maxKeys || n.key(idx) == 0 {
+	idx := n.search(k, t.maxKeys)
+	if idx == t.maxKeys || n.key(idx) == 0 {
 		return 0
 	}
 	child := t.node(n.uint64(valOffset(idx)))
@@ -98,80 +91,77 @@ func (t *Tree) get(n node, k uint64) uint64 {
 
 // DeleteBelow sets value 0, for all the keys which have value below ts
 func (t *Tree) DeleteBelow(ts uint64) {
-	fn := func(n node, idx int) {
-		if n.val(idx) < ts {
-			n.setAt(valOffset(idx), 0)
-		}
+	fn := func(n node) {
+		// Set the values to 0.
+		n.iterate(func(n node, idx int) {
+			if n.val(idx) < ts {
+				n.setAt(valOffset(idx), 0)
+			}
+		}, t.maxKeys)
+		// remove the deleted entries from the node.
+		n.compact(t.maxKeys)
 	}
-	t.Iterate(fn, true)
+	t.Iterate(fn)
 }
 
-func (t *Tree) iterate(n node, fn func(node, int), doCompact bool) {
-	if n.isLeaf() {
-		n.iterate(fn)
-		if doCompact {
-			n.compact()
-		}
+func (t *Tree) iterate(n node, fn func(node)) {
+	if n.isLeaf(t.maxKeys) {
+		fn(n)
 		return
 	}
-	for i := 0; i < maxKeys; i++ {
+	for i := 0; i < t.maxKeys; i++ {
 		if n.key(i) == 0 {
 			return
 		}
-		childId := n.uint64(valOffset(i))
-		child := t.node(childId)
-		t.iterate(child, fn, doCompact)
+		childID := n.uint64(valOffset(i))
+		child := t.node(childID)
+		t.iterate(child, fn)
 	}
 }
 
-// Iterate iterates ove the tree
-func (t *Tree) Iterate(fn func(node, int), doCompact bool) {
+// Iterate iterates over the tree and executes the fn on each leaf node. It is
+// the responsibility of caller to iterate over all the kvs in a leaf node.
+func (t *Tree) Iterate(fn func(node)) {
 	root := t.node(1)
-	t.iterate(root, fn, doCompact)
+	t.iterate(root, fn)
 	fmt.Println("Done iterating")
 }
 
-func (t *Tree) print(n node, parentId uint64) {
-	// fmt.Printf("print called with n: %v, parentId: %d\n", &n[0], parentId)
-	n.print(parentId)
-	if n.isLeaf() {
+func (t *Tree) print(n node, parentID uint64) {
+	n.print(parentID, t.maxKeys)
+	if n.isLeaf(t.maxKeys) {
 		return
 	}
-	pid := n.pageId()
-	for i := 0; i < maxKeys; i++ {
+	pid := n.pageID(t.maxKeys)
+	for i := 0; i < t.maxKeys; i++ {
 		if n.key(i) == 0 {
 			return
 		}
-		childId := n.uint64(valOffset(i))
-		child := t.node(childId)
+		childID := n.uint64(valOffset(i))
+		child := t.node(childID)
 		t.print(child, pid)
 	}
 }
 
+// Print iterates over the tree and prints all valid KVs.
 func (t *Tree) Print() {
 	root := t.node(1)
 	t.print(root, 0)
-	fmt.Println("Done")
 }
 
 // For internal nodes, they contain <key, ptr>.
 // where all entries <= key are stored in the corresponding ptr.
 func (t *Tree) set(n node, k, v uint64) {
-	if n.isLeaf() {
-		n.set(k, v)
+	if n.isLeaf(t.maxKeys) {
+		n.set(k, v, t.maxKeys)
 		return
 	}
 
 	// This is an internal node.
-	idx := n.search(k)
-	if idx >= maxKeys {
-		// We can just upgrade the key at maxKeys-1, so all key-values under k
-		// would get stored in the same child.
+	idx := n.search(k, t.maxKeys)
+	if idx >= t.maxKeys {
 		panic("this shouldn't happen")
-		n.setAt(keyOffset(maxKeys-1), k)
-		idx = maxKeys - 1
 	}
-	// fmt.Printf("found key: %d for inserting %d for pageid: %d\n", n.key(idx), k, n.pageId())
 	// If no key at idx.
 	if n.key(idx) == 0 {
 		n.setAt(keyOffset(idx), k)
@@ -179,36 +169,28 @@ func (t *Tree) set(n node, k, v uint64) {
 	child := t.node(n.uint64(valOffset(idx)))
 	if child == nil {
 		child = t.newNode(bitLeaf)
-		n.setAt(valOffset(idx), child.pageId())
-		fmt.Printf("child is nil. Created child with id: %d\n", child.pageId())
+		n.setAt(valOffset(idx), child.pageID(t.maxKeys))
 	}
-	fmt.Printf("setting %d at child: %d\n", k, child.pageId())
 	t.set(child, k, v)
 
-	if child.isFull() {
+	if child.isFull(t.maxKeys) {
 		// Split child.
-		fmt.Println("Before")
-		n.print(0)
-		fmt.Printf("Child %d is full. Splitting\n", child.pageId())
 		nn := t.split(child)
 
 		// Set children.
-		n.set(child.maxKey(), child.pageId())
-		n.set(nn.maxKey(), nn.pageId())
-		n.print(0)
-		child.print(n.pageId())
-		nn.print(n.pageId())
+		n.set(child.maxKey(t.maxKeys), child.pageID(t.maxKeys), t.maxKeys)
+		n.set(nn.maxKey(t.maxKeys), nn.pageID(t.maxKeys), t.maxKeys)
 	}
 }
 
 func (t *Tree) split(n node) node {
-	if !n.isFull() {
+	if !n.isFull(t.maxKeys) {
 		panic("This should be called only when n is full")
 	}
-	rightHalf := n[keyOffset(maxKeys/2):keyOffset(maxKeys)]
+	rightHalf := n[keyOffset(t.maxKeys/2):keyOffset(t.maxKeys)]
 
 	// Create a new node nn, copy over half the keys from n, and set the parent to n's parent.
-	nn := t.newNode(n.bits())
+	nn := t.newNode(n.bits(t.maxKeys))
 	copy(nn, rightHalf)
 
 	// Remove entries from node n.
@@ -228,23 +210,19 @@ func (n node) uint64(start int) uint64 {
 	return binary.BigEndian.Uint64(n[start : start+8])
 }
 
-func keyOffset(i int) int        { return 16 * i }   // Last 16 bytes are kept off limits.
-func valOffset(i int) int        { return 16*i + 8 } // Last 16 bytes are kept off limits.
-func (n node) pageId() uint64    { return n.uint64(keyOffset(maxKeys)) }
-func (n node) key(i int) uint64  { return n.uint64(keyOffset(i)) }
-func (n node) val(i int) uint64  { return n.uint64(valOffset(i)) }
-func (n node) id() uint64        { return n.key(maxKeys) }
-func (n node) data(i int) []byte { return n[keyOffset(i):keyOffset(i+1)] }
+func keyOffset(i int) int                { return 16 * i }   // Last 16 bytes are kept off limits.
+func valOffset(i int) int                { return 16*i + 8 } // Last 16 bytes are kept off limits.
+func (n node) pageID(maxKeys int) uint64 { return n.uint64(keyOffset(maxKeys)) }
+func (n node) key(i int) uint64          { return n.uint64(keyOffset(i)) }
+func (n node) val(i int) uint64          { return n.uint64(valOffset(i)) }
+func (n node) id(maxKeys int) uint64     { return n.key(maxKeys) }
+func (n node) data(i int) []byte         { return n[keyOffset(i):keyOffset(i+1)] }
 
-func (n node) next(k uint64) node {
-	return nil
-}
 func (n node) setAt(start int, k uint64) {
-	// fmt.Printf("setAt: %d %d with pageId: %d\n", start, k, n.pageId())
 	binary.BigEndian.PutUint64(n[start:start+8], k)
 }
-func (n node) moveRight(lo int) {
-	hi := n.search(math.MaxUint64)
+func (n node) moveRight(lo int, maxKeys int) {
+	hi := n.search(math.MaxUint64, maxKeys)
 	if hi == maxKeys {
 		panic("endIdx == maxKeys")
 	}
@@ -258,25 +236,25 @@ const (
 	bitLeaf = uint64(2)
 )
 
-func (n node) setBit(b uint64) {
+func (n node) setBit(b uint64, maxKeys int) {
 	vo := valOffset(maxKeys)
 	v := n.uint64(vo)
 	n.setAt(vo, v|b)
 }
-func (n node) bits() uint64 {
+func (n node) bits(maxKeys int) uint64 {
 	vo := valOffset(maxKeys)
 	return n.uint64(vo)
 }
 
-func (n node) isLeaf() bool {
+func (n node) isLeaf(maxKeys int) bool {
 	return n.uint64(valOffset(maxKeys))&bitLeaf > 0
 }
 
 // isFull checks that the node is already full.
-func (n node) isFull() bool {
+func (n node) isFull(maxKeys int) bool {
 	return n.key(maxKeys-1) > 0
 }
-func (n node) search(k uint64) int {
+func (n node) search(k uint64, maxKeys int) int {
 	return sort.Search(maxKeys, func(i int) bool {
 		// ks := n.keyAt(i + 1)
 		ks := n.key(i)
@@ -286,8 +264,8 @@ func (n node) search(k uint64) int {
 		return ks >= k
 	})
 }
-func (n node) maxKey() uint64 {
-	idx := n.search(math.MaxUint64)
+func (n node) maxKey(maxKeys int) uint64 {
+	idx := n.search(math.MaxUint64, maxKeys)
 	// idx points to the first key which is zero.
 	if idx > 0 {
 		idx--
@@ -296,29 +274,30 @@ func (n node) maxKey() uint64 {
 }
 
 // compacts the node i.e., remove all the kvs with value 0. It returns the remaining number of keys.
-func (n node) compact() int {
+func (n node) compact(maxKeys int) int {
 	// compact should be called only on leaf nodes
-	assert(n.isLeaf())
-	var si, di int
-	for si < maxKeys {
-		if n.key(si) == 0 {
+	assert(n.isLeaf(maxKeys))
+	var left, right int
+	for right < maxKeys {
+		if n.key(right) == 0 {
 			break
 		}
-		if di != si {
-			copy(n.data(di), n.data(si))
+		// If the value is non-zero, move the kv to right.
+		if n.val(right) != 0 {
+			if left != right {
+				copy(n.data(left), n.data(right))
+			}
+			left++
 		}
-		if n.val(si) != 0 {
-			di++
-		}
-		si++
+		right++
 	}
 	// zero out rest of the kv pairs
-	ZeroOut(n, keyOffset(di), keyOffset(si))
-	return di
+	ZeroOut(n, keyOffset(left), keyOffset(right))
+	return left
 }
 
-func (n node) get(k uint64) uint64 {
-	idx := n.search(k)
+func (n node) get(k uint64, maxKeys int) uint64 {
+	idx := n.search(k, maxKeys)
 	// key is not found
 	if idx == maxKeys {
 		return 0
@@ -328,8 +307,8 @@ func (n node) get(k uint64) uint64 {
 	}
 	return 0
 }
-func (n node) set(k, v uint64) {
-	idx := n.search(k)
+func (n node) set(k, v uint64, maxKeys int) {
+	idx := n.search(k, maxKeys)
 	if idx == maxKeys {
 		panic("node should not be full")
 	}
@@ -343,7 +322,7 @@ func (n node) set(k, v uint64) {
 		// Found the first entry which is greater than k. So, we need to fit k
 		// just before it. For that, we should move the rest of the data in the
 		// node to the right to make space for k.
-		n.moveRight(idx)
+		n.moveRight(idx, maxKeys)
 		n.setAt(keyOffset(idx), k)
 		n.setAt(valOffset(idx), v)
 		return
@@ -351,7 +330,7 @@ func (n node) set(k, v uint64) {
 	panic("shouldn't reach here")
 }
 
-func (n node) iterate(fn func(node, int)) {
+func (n node) iterate(fn func(node, int), maxKeys int) {
 	for i := 0; i < maxKeys; i++ {
 		if k := n.key(i); k > 0 {
 			fn(n, i)
@@ -361,25 +340,17 @@ func (n node) iterate(fn func(node, int)) {
 	}
 }
 
-func (n node) print(parentId uint64) {
+func (n node) print(parentID uint64, maxKeys int) {
 	var keys []string
-	for i := 0; i < maxKeys; i++ {
-		if k := n.key(i); k > 0 {
-			keys = append(keys, fmt.Sprintf("%d", k))
-		} else {
-			break
-		}
-	}
+	n.iterate(func(n node, i int) {
+		keys = append(keys, fmt.Sprintf("%d", n.key(i)))
+	}, maxKeys)
 	if len(keys) > 8 {
 		copy(keys[4:], keys[len(keys)-4:])
 		keys[3] = "..."
 		keys = keys[:8]
 	}
-	idx := n.search(math.MaxUint64)
-	numKeys := idx
-	if idx > 0 {
-		idx--
-	}
+	numKeys := n.search(math.MaxUint64, maxKeys)
 	fmt.Printf("%d Child of: %d bits: %04b num keys: %d, keys: %s\n",
-		n.pageId(), parentId, n.bits(), numKeys, strings.Join(keys, " "))
+		n.pageID(maxKeys), parentID, n.bits(maxKeys), numKeys, strings.Join(keys, " "))
 }

--- a/z/btree_test.go
+++ b/z/btree_test.go
@@ -1,0 +1,42 @@
+package z
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTree(t *testing.T) {
+	f, err := ioutil.TempFile(".", "tree")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+
+	mf, err := OpenMmapFileUsing(f, 1<<30, true)
+	if err != NewFile {
+		require.NoError(t, err)
+	}
+	defer mf.Close(0)
+
+	bt := NewTree(mf, 8)
+	bt.Print()
+
+	N := uint64(256 * 256)
+	for i := uint64(1); i < N; i++ {
+		bt.Set(i, i)
+	}
+	// TODO: Add a bt.Get and check that it works.
+	bt.Print()
+}
+
+func TestNode(t *testing.T) {
+	n := node(make([]byte, pageSize))
+	for i := uint64(1); i < 16; i *= 2 {
+		n.set(i, i)
+	}
+	n.print(0)
+
+	n.set(5, 5)
+	n.print(0)
+}

--- a/z/btree_test.go
+++ b/z/btree_test.go
@@ -2,6 +2,8 @@ package z
 
 import (
 	"io/ioutil"
+	"math"
+	"math/rand"
 	"os"
 	"testing"
 
@@ -26,8 +28,41 @@ func TestTree(t *testing.T) {
 	for i := uint64(1); i < N; i++ {
 		bt.Set(i, i)
 	}
-	// TODO: Add a bt.Get and check that it works.
+	for i := uint64(1); i < N; i++ {
+		require.Equal(t, i, bt.Get(i))
+	}
 	bt.Print()
+}
+
+func TestTreeBasic(t *testing.T) {
+	setAndGet := func() {
+		f, err := ioutil.TempFile(".", "tree")
+		require.NoError(t, err)
+		defer os.Remove(f.Name())
+
+		mf, err := OpenMmapFileUsing(f, 1<<30, true)
+		if err != NewFile {
+			require.NoError(t, err)
+		}
+		defer mf.Close(0)
+
+		bt := NewTree(mf, 8)
+
+		N := uint64(256 * 256)
+		mp := make(map[uint64]uint64)
+		for i := uint64(1); i < N; i++ {
+			key := uint64(rand.Int63n(1<<60) + 1)
+			bt.Set(key, key)
+			mp[key] = key
+		}
+		for k, v := range mp {
+			require.Equal(t, v, bt.Get(k))
+		}
+	}
+	setAndGet()
+	pageSize = 16 << 4
+	maxKeys = (pageSize / 16) - 1
+	setAndGet()
 }
 
 func TestNode(t *testing.T) {
@@ -36,7 +71,21 @@ func TestNode(t *testing.T) {
 		n.set(i, i)
 	}
 	n.print(0)
-
+	require.True(t, math.MaxUint64 == n.get(5))
 	n.set(5, 5)
 	n.print(0)
+}
+
+func TestNodeBasic(t *testing.T) {
+	n := node(make([]byte, pageSize))
+	N := uint64(256)
+	mp := make(map[uint64]uint64)
+	for i := uint64(1); i < N; i++ {
+		key := uint64(rand.Int63n(1<<60) + 1)
+		n.set(key, key)
+		mp[key] = key
+	}
+	for k, v := range mp {
+		require.Equal(t, v, n.get(k))
+	}
 }

--- a/z/btree_test.go
+++ b/z/btree_test.go
@@ -1,6 +1,7 @@
 package z
 
 import (
+	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -20,7 +21,7 @@ func TestTree(t *testing.T) {
 	}
 	defer mf.Close(0)
 
-	bt := NewTree(mf, 8)
+	bt := NewTree(mf, os.Getpagesize())
 	bt.Print()
 
 	N := uint64(256 * 256)
@@ -43,7 +44,7 @@ func TestTree(t *testing.T) {
 }
 
 func TestTreeBasic(t *testing.T) {
-	setAndGet := func() {
+	setAndGet := func(pageSize int) {
 		f, err := ioutil.TempFile(".", "tree")
 		require.NoError(t, err)
 		defer os.Remove(f.Name())
@@ -54,9 +55,9 @@ func TestTreeBasic(t *testing.T) {
 		}
 		defer mf.Close(0)
 
-		bt := NewTree(mf, 8)
+		bt := NewTree(mf, pageSize)
 
-		N := uint64(256 * 256)
+		N := uint64(1 << 20)
 		mp := make(map[uint64]uint64)
 		for i := uint64(1); i < N; i++ {
 			key := uint64(rand.Int63n(1<<60) + 1)
@@ -67,44 +68,44 @@ func TestTreeBasic(t *testing.T) {
 			require.Equal(t, v, bt.Get(k))
 		}
 	}
-	setAndGet()
-	defer func() {
-		pageSize = os.Getpagesize()
-		maxKeys = (pageSize / 16) - 1
-	}()
-	pageSize = 16 << 4
-	maxKeys = (pageSize / 16) - 1
-	setAndGet()
+	setAndGet(os.Getpagesize())
+	setAndGet(16 << 2)
 }
 
 func TestNode(t *testing.T) {
+	pageSize := os.Getpagesize()
+	maxKeys := (pageSize / 16) - 1
 	n := node(make([]byte, pageSize))
 	for i := uint64(1); i < 16; i *= 2 {
-		n.set(i, i)
+		n.set(i, i, maxKeys)
 	}
-	n.print(0)
-	require.True(t, 0 == n.get(5))
-	n.set(5, 5)
-	n.print(0)
+	n.print(0, maxKeys)
+	require.True(t, 0 == n.get(5, maxKeys))
+	n.set(5, 5, maxKeys)
+	n.print(0, maxKeys)
 }
 
 func TestNodeBasic(t *testing.T) {
+	pageSize := os.Getpagesize()
+	maxKeys := (pageSize / 16) - 1
 	n := node(make([]byte, pageSize))
 	N := uint64(256)
 	mp := make(map[uint64]uint64)
 	for i := uint64(1); i < N; i++ {
 		key := uint64(rand.Int63n(1<<60) + 1)
-		n.set(key, key)
+		n.set(key, key, maxKeys)
 		mp[key] = key
 	}
 	for k, v := range mp {
-		require.Equal(t, v, n.get(k))
+		require.Equal(t, v, n.get(k, maxKeys))
 	}
 }
 
 func TestNodeCompact(t *testing.T) {
+	pageSize := os.Getpagesize()
+	maxKeys := (pageSize / 16) - 1
 	n := node(make([]byte, pageSize))
-	n.setBit(bitLeaf)
+	n.setBit(bitLeaf, maxKeys)
 	N := uint64(256)
 	mp := make(map[uint64]uint64)
 	for i := uint64(1); i < N; i++ {
@@ -114,10 +115,80 @@ func TestNodeCompact(t *testing.T) {
 			val = key / 2
 			mp[key] = val
 		}
-		n.set(key, val)
+		n.set(key, val, maxKeys)
 	}
-	require.Equal(t, 255/2, n.compact())
+	require.Equal(t, 255/2, n.compact(maxKeys))
 	for k, v := range mp {
-		require.Equal(t, v, n.get(k))
+		require.Equal(t, v, n.get(k, maxKeys))
 	}
+}
+
+func BenchmarkWrite(b *testing.B) {
+	b.Run("map", func(b *testing.B) {
+		mp := make(map[uint64]uint64)
+		for n := 0; n < b.N; n++ {
+			k := rand.Uint64()
+			mp[k] = k
+		}
+	})
+	b.Run("btree", func(b *testing.B) {
+		f, err := ioutil.TempFile(".", "tree")
+		require.NoError(b, err)
+		defer os.Remove(f.Name())
+
+		mf, err := OpenMmapFileUsing(f, 1<<30, true)
+		if err != NewFile {
+			require.NoError(b, err)
+		}
+		defer mf.Close(0)
+
+		bt := NewTree(mf, os.Getpagesize())
+		b.ResetTimer()
+		for n := 0; n < b.N; n++ {
+			k := rand.Uint64()
+			bt.Set(k, k)
+		}
+	})
+}
+
+func BenchmarkRead(b *testing.B) {
+	N := 10 << 20
+	b.Run("map", func(b *testing.B) {
+		mp := make(map[uint64]uint64)
+		for i := 0; i < N; i++ {
+			k := uint64(rand.Intn(2 * N))
+			mp[k] = k
+		}
+		b.ResetTimer()
+		for n := 0; n < b.N; n++ {
+			k := uint64(rand.Intn(2 * N))
+			v, ok := mp[k]
+			_, _ = v, ok
+		}
+	})
+	b.Run("btree", func(b *testing.B) {
+		f, err := ioutil.TempFile(".", "tree")
+		require.NoError(b, err)
+		defer os.Remove(f.Name())
+
+		mf, err := OpenMmapFileUsing(f, 1<<30, true)
+		if err != NewFile {
+			require.NoError(b, err)
+		}
+		defer mf.Close(0)
+
+		bt := NewTree(mf, os.Getpagesize())
+		b.ResetTimer()
+		for i := 0; i < N; i++ {
+			k := uint64(rand.Intn(2 * N))
+			bt.Set(k, k)
+		}
+		b.ResetTimer()
+		fmt.Println("Writes done")
+		for i := 0; i < b.N; i++ {
+			k := uint64(rand.Intn(2 * N))
+			v := bt.Get(k)
+			_ = v
+		}
+	})
 }

--- a/z/btree_test.go
+++ b/z/btree_test.go
@@ -5,10 +5,13 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+var tmp int
 
 func setPageSize(sz int) {
 	pageSize = sz
@@ -177,8 +180,6 @@ func BenchmarkRead(b *testing.B) {
 		mp[k] = k
 	}
 	b.Run("map", func(b *testing.B) {
-
-		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			k := uint64(rand.Intn(2 * N))
 			v, ok := mp[k]
@@ -206,11 +207,54 @@ func BenchmarkRead(b *testing.B) {
 	fmt.Println("Writes done")
 
 	b.Run("btree", func(b *testing.B) {
-		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			k := uint64(rand.Intn(2*N)) + 1
 			v := bt.Get(k)
 			_ = v
 		}
 	})
+}
+
+func BenchmarkSearch(b *testing.B) {
+	linear := func(n node, k uint64, N int) int {
+		for i := 0; i < N; i++ {
+			if ki := n.key(i); ki >= k {
+				return i
+			}
+		}
+		return N
+	}
+	binary := func(n node, k uint64, N int) int {
+		return sort.Search(N, func(i int) bool {
+			return n.key(i) >= k
+		})
+	}
+
+	for sz := 1; sz < 256; sz *= 2 {
+		f, err := ioutil.TempFile(".", "tree")
+		require.NoError(b, err)
+
+		mf, err := OpenMmapFileUsing(f, pageSize, true)
+		if err != NewFile {
+			require.NoError(b, err)
+		}
+
+		n := node(mf.Data)
+		for i := 1; i <= sz; i++ {
+			n.set(uint64(i), uint64(i))
+		}
+
+		b.Run(fmt.Sprintf("linear-%d", sz), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				tmp = linear(n, uint64(sz), sz)
+			}
+		})
+		b.Run(fmt.Sprintf("binary-%d", sz), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				tmp = binary(n, uint64(sz), sz)
+			}
+		})
+		mf.Close(0)
+		os.Remove(f.Name())
+	}
 }

--- a/z/btree_test.go
+++ b/z/btree_test.go
@@ -167,6 +167,15 @@ func BenchmarkWrite(b *testing.B) {
 	})
 }
 
+// goos: linux
+// goarch: amd64
+// pkg: github.com/dgraph-io/ristretto/z
+// BenchmarkRead/map-4         	10845322	       109 ns/op
+// BenchmarkRead/btree-4       	 2744283	       430 ns/op
+// Cumulative for 10 runs.
+// name          time/op
+// Read/map-4    105ns ± 1%
+// Read/btree-4  422ns ± 1%
 func BenchmarkRead(b *testing.B) {
 	N := 10 << 20
 	mp := make(map[uint64]uint64)

--- a/z/btree_test.go
+++ b/z/btree_test.go
@@ -2,7 +2,6 @@ package z
 
 import (
 	"io/ioutil"
-	"math"
 	"math/rand"
 	"os"
 	"testing"
@@ -31,6 +30,15 @@ func TestTree(t *testing.T) {
 	for i := uint64(1); i < N; i++ {
 		require.Equal(t, i, bt.Get(i))
 	}
+
+	bt.DeleteBelow(100)
+	for i := uint64(1); i < 100; i++ {
+		require.Equal(t, uint64(0), bt.Get(i))
+	}
+	for i := uint64(100); i < N; i++ {
+		require.Equal(t, i, bt.Get(i))
+	}
+
 	bt.Print()
 }
 
@@ -75,7 +83,7 @@ func TestNode(t *testing.T) {
 		n.set(i, i)
 	}
 	n.print(0)
-	require.True(t, math.MaxUint64 == n.get(5))
+	require.True(t, 0 == n.get(5))
 	n.set(5, 5)
 	n.print(0)
 }

--- a/z/btree_test.go
+++ b/z/btree_test.go
@@ -60,6 +60,10 @@ func TestTreeBasic(t *testing.T) {
 		}
 	}
 	setAndGet()
+	defer func() {
+		pageSize = os.Getpagesize()
+		maxKeys = (pageSize / 16) - 1
+	}()
 	pageSize = 16 << 4
 	maxKeys = (pageSize / 16) - 1
 	setAndGet()

--- a/z/btree_test.go
+++ b/z/btree_test.go
@@ -167,7 +167,7 @@ func BenchmarkRead(b *testing.B) {
 	N := 10 << 20
 	mp := make(map[uint64]uint64)
 	for i := 0; i < N; i++ {
-		k := uint64(rand.Intn(2 * N))
+		k := uint64(rand.Intn(2*N)) + 1
 		mp[k] = k
 	}
 	b.Run("map", func(b *testing.B) {
@@ -192,7 +192,7 @@ func BenchmarkRead(b *testing.B) {
 
 	bt := NewTree(mf, os.Getpagesize())
 	for i := 0; i < N; i++ {
-		k := uint64(rand.Intn(2 * N))
+		k := uint64(rand.Intn(2*N)) + 1
 		bt.Set(k, k)
 	}
 	np := bt.NumPages()
@@ -202,7 +202,7 @@ func BenchmarkRead(b *testing.B) {
 	b.Run("btree", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			k := uint64(rand.Intn(2 * N))
+			k := uint64(rand.Intn(2*N)) + 1
 			v := bt.Get(k)
 			_ = v
 		}

--- a/z/btree_test.go
+++ b/z/btree_test.go
@@ -3,6 +3,7 @@ package z
 import (
 	"fmt"
 	"io/ioutil"
+	"math"
 	"math/rand"
 	"os"
 	"sort"
@@ -49,10 +50,10 @@ func TestTree(t *testing.T) {
 	}
 
 	bt.DeleteBelow(100)
-	for i := uint64(1); i < 100; i++ {
+	for i := uint64(1); i <= 100; i++ {
 		require.Equal(t, uint64(0), bt.Get(i))
 	}
-	for i := uint64(100); i < N; i++ {
+	for i := uint64(101); i < N; i++ {
 		require.Equal(t, i, bt.Get(i))
 	}
 
@@ -129,18 +130,23 @@ func TestNode_MoveRight(t *testing.T) {
 func TestNodeCompact(t *testing.T) {
 	n := node(make([]byte, pageSize))
 	n.setBit(bitLeaf)
-	N := uint64(256)
+	N := uint64(128)
 	mp := make(map[uint64]uint64)
-	for i := uint64(1); i < N; i++ {
+	for i := uint64(1); i <= N; i++ {
 		key := uint64(rand.Int63n(1<<60) + 1)
-		val := uint64(0)
+		val := uint64(10)
 		if i%2 == 0 {
-			val = key / 2
-			mp[key] = val
+			val = 20
+			mp[key] = 20
 		}
 		n.set(key, val)
 	}
-	require.Equal(t, 255/2, n.compact())
+
+	// MaxUint64-1 should not be removed though it has value less than delete below.
+	mkey := uint64(math.MaxUint64 - 1)
+	n.set(mkey, 0)
+	mp[mkey] = 0
+	require.Equal(t, int(N/2+1), n.compact(10))
 	for k, v := range mp {
 		require.Equal(t, v, n.get(k))
 	}

--- a/z/btree_test.go
+++ b/z/btree_test.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/dustin/go-humanize"
 	"github.com/stretchr/testify/require"
 )
 
@@ -203,8 +204,8 @@ func BenchmarkRead(b *testing.B) {
 		bt.Set(k, k)
 	}
 	np := bt.NumPages()
-	fmt.Printf("Num pages: %d Size: %d\n", np, np*pageSize)
-	fmt.Println("Writes done")
+	fmt.Printf("Num pages: %d Size: %s\n", np, humanize.IBytes(uint64(np*pageSize)))
+	fmt.Println("Writes done.")
 
 	b.Run("btree", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {

--- a/z/btree_test.go
+++ b/z/btree_test.go
@@ -101,3 +101,23 @@ func TestNodeBasic(t *testing.T) {
 		require.Equal(t, v, n.get(k))
 	}
 }
+
+func TestNodeCompact(t *testing.T) {
+	n := node(make([]byte, pageSize))
+	n.setBit(bitLeaf)
+	N := uint64(256)
+	mp := make(map[uint64]uint64)
+	for i := uint64(1); i < N; i++ {
+		key := uint64(rand.Int63n(1<<60) + 1)
+		val := uint64(0)
+		if i%2 == 0 {
+			val = key / 2
+			mp[key] = val
+		}
+		n.set(key, val)
+	}
+	require.Equal(t, 255/2, n.compact())
+	for k, v := range mp {
+		require.Equal(t, v, n.get(k))
+	}
+}


### PR DESCRIPTION
This PR adds a custom mmaped B+ tree. This data structure creates a mapping from uint64 to uint64.
**Structure of node:** 
Each node in the node is of size pageSize. Two kinds of nodes. Leaf nodes and internal nodes.
Leaf nodes only contain the data. Internal nodes would contain the key and the offset to the child node.
Internal node would have first entry as:
`<0 offset to child>, <1000 offset>, <5000 offset>, and so on...`
Leaf nodes would just have: <key, value>, <key, value>, and so on...
Last 16 bytes of the node are off limits.
`| pageID (8 bytes) | metaBits (1 byte) | 3 free bytes | numKeys (4 bytes) |`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/207)
<!-- Reviewable:end -->
