### PR TITLE
fix(btree): make delete below delete values that are less than lo

### DIFF
--- a/z/btree.go
+++ b/z/btree.go
@@ -380,7 +380,7 @@ func (n node) maxKey() uint64 {
 	return n.key(idx)
 }
 
-// compacts the node i.e., remove all the kvs with value <= lo. It returns the remaining number of
+// compacts the node i.e., remove all the kvs with value < lo. It returns the remaining number of
 // keys.
 func (n node) compact(lo uint64) int {
 	// compact should be called only on leaf nodes
@@ -388,12 +388,12 @@ func (n node) compact(lo uint64) int {
 	N := n.numKeys()
 	mk := n.maxKey()
 	// Just zero-out the value of maxKey if value <= lo. Don't remove the key.
-	if N > 0 && n.val(N-1) <= lo {
+	if N > 0 && n.val(N-1) < lo {
 		n.setAt(valOffset(N-1), 0)
 	}
 	var left, right int
 	for right = 0; right < N; right++ {
-		if n.val(right) <= lo && n.key(right) < mk {
+		if n.val(right) < lo && n.key(right) < mk {
 			// Skip over this key. Don't copy it.
 			continue
 		}

--- a/z/btree_test.go
+++ b/z/btree_test.go
@@ -48,10 +48,10 @@ func TestTree(t *testing.T) {
 	}
 
 	bt.DeleteBelow(100)
-	for i := uint64(1); i <= 100; i++ {
+	for i := uint64(1); i < 100; i++ {
 		require.Equal(t, uint64(0), bt.Get(i))
 	}
-	for i := uint64(101); i < N; i++ {
+	for i := uint64(100); i < N; i++ {
 		require.Equal(t, i, bt.Get(i))
 	}
 	// bt.Print()
@@ -170,7 +170,7 @@ func TestNodeCompact(t *testing.T) {
 		n.set(key, val)
 	}
 
-	require.Equal(t, int(N/2), n.compact(10))
+	require.Equal(t, int(N/2), n.compact(11))
 	for k, v := range mp {
 		require.Equal(t, v, n.get(k))
 	}


### PR DESCRIPTION
This PR changes the compact to delete all the keys with values **less** than lo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/211)
<!-- Reviewable:end -->
