### PR TITLE
Fix infinite loop in allocator

### DIFF
--- a/z/allocator.go
+++ b/z/allocator.go
@@ -115,9 +115,9 @@ func ReturnAllocator(a *Allocator) {
 func NewAllocator(sz int) *Allocator {
 	ref := atomic.AddUint64(&allocRef, 1)
 	// We should not allow a zero sized page because addBufferWithMinSize
-	// will run into an infinite loop tyring to double the pagesize.
+	// will run into an infinite loop trying to double the pagesize.
 	if sz == 0 {
-		sz = 1
+		sz = smallBufferSize
 	}
 	a := &Allocator{
 		pageSize: sz,
@@ -378,6 +378,7 @@ func (a *Allocator) Allocate(sz int) []byte {
 		}
 		cb = a.buffers[a.curBuf]
 	}
+
 	slice := cb[a.curIdx : a.curIdx+sz]
 	a.curIdx += sz
 	a.size += uint64(sz)

--- a/z/allocator.go
+++ b/z/allocator.go
@@ -114,6 +114,11 @@ func ReturnAllocator(a *Allocator) {
 // NewAllocator creates an allocator starting with the given size.
 func NewAllocator(sz int) *Allocator {
 	ref := atomic.AddUint64(&allocRef, 1)
+	// We should not allow a zero sized page because addBufferWithMinSize
+	// will run into an infinite loop tyring to double the pagesize.
+	if sz == 0 {
+		sz = 1
+	}
 	a := &Allocator{
 		pageSize: sz,
 		Ref:      ref,
@@ -373,7 +378,6 @@ func (a *Allocator) Allocate(sz int) []byte {
 		}
 		cb = a.buffers[a.curBuf]
 	}
-
 	slice := cb[a.curIdx : a.curIdx+sz]
 	a.curIdx += sz
 	a.size += uint64(sz)


### PR DESCRIPTION
If we create a new allocator starting with zero size, then addBufferWithMinSize() will run into an infinite loop, trying to achieve the required buffer size by doubling the pagesize (which is zero).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/214)
<!-- Reviewable:end -->
