### PR TITLE
chore(buffer): add a parent directory field in z.Buffer

### DIFF
--- a/z/buffer.go
+++ b/z/buffer.go
@@ -74,11 +74,19 @@ const smallBufferSize = 64
 
 // NewBuffer is a helper utility, which creates a virtually unlimited Buffer in UseCalloc mode.
 func NewBuffer(sz int) *Buffer {
-	buf, err := NewBufferWith(sz, 256<<30, UseCalloc, "")
+	buf, err := NewBufferWithDir(sz, 256<<30, UseCalloc, "")
 	if err != nil {
 		log.Fatalf("while creating buffer: %v", err)
 	}
 	return buf
+}
+
+// NewBufferWith would allocate a buffer of size sz upfront, with the total size of the buffer not
+// exceeding maxSz. Both sz and maxSz can be set to zero, in which case reasonable defaults would be
+// used. Buffer can't be used without initialization via NewBuffer.
+func NewBufferWith(sz, maxSz int, bufType BufferType) (*Buffer, error) {
+	buf, err := NewBufferWithDir(sz, maxSz, bufType, "")
+	return buf, err
 }
 
 func (b *Buffer) doMmap() error {
@@ -105,10 +113,11 @@ func (b *Buffer) doMmap() error {
 	return nil
 }
 
-// NewBufferWith would allocate a buffer of size sz upfront, with the total size of the buffer not
-// exceeding maxSz. Both sz and maxSz can be set to zero, in which case reasonable defaults would be
-// used. Buffer can't be used without initialization via NewBuffer.
-func NewBufferWith(sz, maxSz int, bufType BufferType, dir string) (*Buffer, error) {
+// NewBufferWithDir would allocate a buffer of size sz upfront, with the total size of the buffer
+// not exceeding maxSz. Both sz and maxSz can be set to zero, in which case reasonable defaults
+// would be used. Buffer can't be used without initialization via NewBuffer. The buffer is created
+// inside dir. The caller should take care of existence of dir.
+func NewBufferWithDir(sz, maxSz int, bufType BufferType, dir string) (*Buffer, error) {
 	if sz == 0 {
 		sz = smallBufferSize
 	}

--- a/z/buffer.go
+++ b/z/buffer.go
@@ -71,7 +71,19 @@ const (
 // smallBufferSize is an initial allocation minimal capacity.
 const smallBufferSize = 64
 
-// Newbuffer is a helper utility, which creates a virtually unlimited Buffer in UseCalloc mode.
+var bufferDir string
+
+// SetBufferDir sets the parent directory for the mmaped buffers.
+func SetBufferDir(dir string) {
+	bufferDir = dir
+}
+
+// ResetBufferDir resets the parent directory for mmaped buffers.
+func ResetBufferDir() {
+	bufferDir = ""
+}
+
+// NewBuffer is a helper utility, which creates a virtually unlimited Buffer in UseCalloc mode.
 func NewBuffer(sz int) *Buffer {
 	buf, err := NewBufferWith(sz, 256<<30, UseCalloc)
 	if err != nil {
@@ -82,7 +94,7 @@ func NewBuffer(sz int) *Buffer {
 
 func (b *Buffer) doMmap() error {
 	curBuf := b.buf
-	fd, err := ioutil.TempFile("", "buffer")
+	fd, err := ioutil.TempFile(bufferDir, "buffer")
 	if err != nil {
 		return err
 	}

--- a/z/buffer_test.go
+++ b/z/buffer_test.go
@@ -38,7 +38,7 @@ func TestBuffer(t *testing.T) {
 			var bytesBuffer bytes.Buffer // This is just for verifying result.
 			bytesBuffer.Grow(512)
 
-			cBuffer, err := NewBufferWith(512, 4<<30, btype)
+			cBuffer, err := NewBufferWith(512, 4<<30, btype, "")
 			require.Nil(t, err)
 			defer cBuffer.Release()
 
@@ -71,7 +71,7 @@ func TestBufferWrite(t *testing.T) {
 			var wb [128]byte
 			rand.Read(wb[:])
 
-			cb, err := NewBufferWith(32, 4<<30, btype)
+			cb, err := NewBufferWith(32, 4<<30, btype, "")
 			require.Nil(t, err)
 			defer cb.Release()
 
@@ -153,7 +153,7 @@ func TestBufferSlice(t *testing.T) {
 	for btype := UseCalloc; btype < UseInvalid; btype++ {
 		name := fmt.Sprintf("Using mode %s", btype)
 		t.Run(name, func(t *testing.T) {
-			buf, err := NewBufferWith(0, 0, btype)
+			buf, err := NewBufferWith(0, 0, btype, "")
 			require.Nil(t, err)
 			defer buf.Release()
 
@@ -208,7 +208,7 @@ func TestBufferSort(t *testing.T) {
 	for btype := UseCalloc; btype < UseInvalid; btype++ {
 		name := fmt.Sprintf("Using mode %s", btype)
 		t.Run(name, func(t *testing.T) {
-			buf, err := NewBufferWith(0, 0, btype)
+			buf, err := NewBufferWith(0, 0, btype, "")
 			require.Nil(t, err)
 			defer buf.Release()
 

--- a/z/buffer_test.go
+++ b/z/buffer_test.go
@@ -38,7 +38,7 @@ func TestBuffer(t *testing.T) {
 			var bytesBuffer bytes.Buffer // This is just for verifying result.
 			bytesBuffer.Grow(512)
 
-			cBuffer, err := NewBufferWith(512, 4<<30, btype, "")
+			cBuffer, err := NewBufferWith(512, 4<<30, btype)
 			require.Nil(t, err)
 			defer cBuffer.Release()
 
@@ -71,7 +71,7 @@ func TestBufferWrite(t *testing.T) {
 			var wb [128]byte
 			rand.Read(wb[:])
 
-			cb, err := NewBufferWith(32, 4<<30, btype, "")
+			cb, err := NewBufferWith(32, 4<<30, btype)
 			require.Nil(t, err)
 			defer cb.Release()
 
@@ -153,7 +153,7 @@ func TestBufferSlice(t *testing.T) {
 	for btype := UseCalloc; btype < UseInvalid; btype++ {
 		name := fmt.Sprintf("Using mode %s", btype)
 		t.Run(name, func(t *testing.T) {
-			buf, err := NewBufferWith(0, 0, btype, "")
+			buf, err := NewBufferWith(0, 0, btype)
 			require.Nil(t, err)
 			defer buf.Release()
 
@@ -208,7 +208,7 @@ func TestBufferSort(t *testing.T) {
 	for btype := UseCalloc; btype < UseInvalid; btype++ {
 		name := fmt.Sprintf("Using mode %s", btype)
 		t.Run(name, func(t *testing.T) {
-			buf, err := NewBufferWith(0, 0, btype, "")
+			buf, err := NewBufferWith(0, 0, btype)
 			require.Nil(t, err)
 			defer buf.Release()
 


### PR DESCRIPTION
This PR adds a `dir` field inside z.Buffer. This field is the parent directory for the mmaped buffers created. If the field is not specified(i.e., it is ""), then it uses `/tmp` (default).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/215)
<!-- Reviewable:end -->
