### PR TITLE
fix(buffer): Make padding internal to z.buffer

### DIFF
--- a/z/buffer.go
+++ b/z/buffer.go
@@ -225,7 +225,8 @@ func (b *Buffer) Allocate(n int) []byte {
 func (b *Buffer) AllocateOffset(n int) int {
 	b.Grow(n)
 	b.offset += uint64(n)
-	return int(b.offset) - n
+	// Remove padding from the offset because the padding should be invisible to the API caller.
+	return int(b.offset) - n - b.StartOffset()
 }
 
 // IncrementOffset returns the incremented offset. This operation is thread-safe. This API should be
@@ -236,7 +237,8 @@ func (b *Buffer) IncrementOffset(n int) int {
 	if out > b.curSz {
 		panic("Buffer size limit hit")
 	}
-	return out
+	// Remove padding from the offset because the padding should be invisible to the API caller.
+	return out - b.StartOffset()
 }
 
 func (b *Buffer) writeLen(sz int) {
@@ -459,7 +461,7 @@ func (b *Buffer) Data(offset int) []byte {
 	if offset > b.curSz {
 		panic("offset beyond current size")
 	}
-	return b.buf[offset:b.curSz]
+	return b.buf[b.StartOffset()+offset : b.curSz]
 }
 
 // Write would write p bytes to the buffer.

--- a/z/buffer_test.go
+++ b/z/buffer_test.go
@@ -248,3 +248,24 @@ func TestBufferSort(t *testing.T) {
 		})
 	}
 }
+
+// Test that AllocateOffset and IncrementOffset returns logical
+// offsets, i.e. excludes padding.
+func TestBufferPadding(t *testing.T) {
+	buf := NewBuffer(1 << 10)
+	sz := rand.Int31n(100)
+
+	writeOffset := buf.AllocateOffset(int(sz))
+	require.Equal(t, 0, writeOffset)
+
+	b := make([]byte, sz)
+	rand.Read(b)
+
+	copy(buf.Bytes(), b)
+	data := buf.Data(0)
+	require.Equal(t, b, data[:sz])
+
+	newOffset := buf.IncrementOffset(int(sz))
+	require.Equal(t, int(sz+sz), newOffset)
+
+}


### PR DESCRIPTION
The caller of the API should not be aware of the padding. It should be handled internally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/216)
<!-- Reviewable:end -->
