### PR TITLE
fix(allocator): make nil allocator return go byte slice

### DIFF
--- a/z/allocator.go
+++ b/z/allocator.go
@@ -330,6 +330,9 @@ func (a *Allocator) addBufferAt(bufIdx, minSz int) {
 }
 
 func (a *Allocator) Allocate(sz int) []byte {
+	if a == nil {
+		return make([]byte, sz)
+	}
 	if sz > maxAlloc {
 		panic(fmt.Sprintf("Unable to allocate more than %d\n", maxAlloc))
 	}


### PR DESCRIPTION
This PR makes nil allocator return a go byte slice. It was removed in [this](https://github.com/dgraph-io/ristretto/commit/4dcfe40a6fc09aa6f68089b5d0ac84e0fedf74ba#diff-db4b53561117c7a98640a172006e01ff55be07cd3fc4a8d34d33283b6b56be6dL350-L352) commit.
At places, in dgraph (e.g [kvs, err := l.Rollup(nil)](https://github.com/dgraph-io/dgraph/blob/af174fda249420da2047a20766ef58259e656396/dgraph/cmd/bulk/reduce.go#L654)) we are using `nil` allocator, and hence causes panic there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/217)
<!-- Reviewable:end -->
