### PR TITLE
Add CanAllocate API

### DIFF
--- a/z/file.go
+++ b/z/file.go
@@ -128,6 +128,11 @@ func (m *MmapFile) AllocateSlice(sz, offset int) ([]byte, int) {
 	return m.Data[offset+4 : offset+4+sz], offset + 4 + sz
 }
 
+// CanAllocate determines whether a slice of the given size can be allocated at the given offset.
+func (m *MmapFile) CanAllocate(sz, offset int) bool {
+	return len(m.Data) <= offset+4+sz
+}
+
 func (m *MmapFile) Sync() error {
 	if m == nil {
 		return nil


### PR DESCRIPTION
`func (m *MmapFile) CanAllocate(sz, offset int) bool` determines whether `AllocateSlice` can be called on an `MmapFile` without exceeding the size of the file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/219)
<!-- Reviewable:end -->
