### PR TITLE
Use mremap on Linux instead of munmap+mmap

### DIFF
--- a/z/file.go
+++ b/z/file.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package z
 
 import (

--- a/z/file_default.go
+++ b/z/file_default.go
@@ -1,0 +1,23 @@
+// +build !linux
+
+package z
+
+import "fmt"
+
+// Truncate would truncate the mmapped file to the given size. On Linux and
+// others, we could directly just truncate the underlying file, but in Windows,
+// we can't do that. So, unmap first, then truncate, then re-map.
+func (m *MmapFile) Truncate(maxSz int64) error {
+	if err := m.Sync(); err != nil {
+		return fmt.Errorf("while sync file: %s, error: %v\n", m.Fd.Name(), err)
+	}
+	if err := Munmap(m.Data); err != nil {
+		return fmt.Errorf("while munmap file: %s, error: %v\n", m.Fd.Name(), err)
+	}
+	if err := m.Fd.Truncate(maxSz); err != nil {
+		return fmt.Errorf("while truncate file: %s, error: %v\n", m.Fd.Name(), err)
+	}
+	var err error
+	m.Data, err = Mmap(m.Fd, true, maxSz) // Mmap up to max size.
+	return err
+}

--- a/z/file_default.go
+++ b/z/file_default.go
@@ -1,12 +1,28 @@
 // +build !linux
 
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package z
 
 import "fmt"
 
-// Truncate would truncate the mmapped file to the given size. On Linux and
-// others, we could directly just truncate the underlying file, but in Windows,
-// we can't do that. So, unmap first, then truncate, then re-map.
+// Truncate would truncate the mmapped file to the given size. On Linux, we truncate
+// the underlying file and then call mremap, but on other systems, we unmap first,
+// then truncate, then re-map.
 func (m *MmapFile) Truncate(maxSz int64) error {
 	if err := m.Sync(); err != nil {
 		return fmt.Errorf("while sync file: %s, error: %v\n", m.Fd.Name(), err)

--- a/z/file_linux.go
+++ b/z/file_linux.go
@@ -2,10 +2,6 @@ package z
 
 import (
 	"fmt"
-	"reflect"
-	"unsafe"
-
-	"golang.org/x/sys/unix"
 )
 
 // Truncate would truncate the mmapped file to the given size. On Linux and
@@ -22,31 +18,4 @@ func (m *MmapFile) Truncate(maxSz int64) error {
 	var err error
 	m.Data, err = mremap(m.Data, int(maxSz)) // Mmap up to max size.
 	return err
-}
-
-func mremap(data []byte, size int) ([]byte, error) {
-	// from <https://github.com/torvalds/linux/blob/f8394f232b1eab649ce2df5c5f15b0e528c92091/include/uapi/linux/mman.h#L8>
-	const MREMAP_MAYMOVE = 0x1
-
-	header := (*reflect.SliceHeader)(unsafe.Pointer(&data))
-	mmapAddr, mmapSize, errno := unix.Syscall6(
-		unix.SYS_MREMAP,
-		header.Data,
-		uintptr(header.Len),
-		uintptr(size),
-		uintptr(MREMAP_MAYMOVE),
-		0,
-		0,
-	)
-	if errno != 0 {
-		return nil, fmt.Errorf("mremap failed with errno: %s", errno)
-	}
-	if mmapSize != uintptr(size) {
-		return nil, fmt.Errorf("mremap size mismatch: requested: %d got: %d", size, mmapSize)
-	}
-
-	header.Data = mmapAddr
-	header.Cap = size
-	header.Len = size
-	return data, nil
 }

--- a/z/file_linux.go
+++ b/z/file_linux.go
@@ -1,0 +1,52 @@
+package z
+
+import (
+	"fmt"
+	"reflect"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// Truncate would truncate the mmapped file to the given size. On Linux and
+// others, we could directly just truncate the underlying file, but in Windows,
+// we can't do that. So, unmap first, then truncate, then re-map.
+func (m *MmapFile) Truncate(maxSz int64) error {
+	if err := m.Sync(); err != nil {
+		return fmt.Errorf("while sync file: %s, error: %v\n", m.Fd.Name(), err)
+	}
+	if err := m.Fd.Truncate(maxSz); err != nil {
+		return fmt.Errorf("while truncate file: %s, error: %v\n", m.Fd.Name(), err)
+	}
+
+	var err error
+	m.Data, err = mremap(m.Data, int(maxSz)) // Mmap up to max size.
+	return err
+}
+
+func mremap(data []byte, size int) ([]byte, error) {
+	// from <https://github.com/torvalds/linux/blob/f8394f232b1eab649ce2df5c5f15b0e528c92091/include/uapi/linux/mman.h#L8>
+	const MREMAP_MAYMOVE = 0x1
+
+	header := (*reflect.SliceHeader)(unsafe.Pointer(&data))
+	mmapAddr, mmapSize, errno := unix.Syscall6(
+		unix.SYS_MREMAP,
+		header.Data,
+		uintptr(header.Len),
+		uintptr(size),
+		uintptr(MREMAP_MAYMOVE),
+		0,
+		0,
+	)
+	if errno != 0 {
+		return nil, fmt.Errorf("mremap failed with errno: %s", errno)
+	}
+	if mmapSize != uintptr(size) {
+		return nil, fmt.Errorf("mremap size mismatch: requested: %d got: %d", size, mmapSize)
+	}
+
+	header.Data = mmapAddr
+	header.Cap = size
+	header.Len = size
+	return data, nil
+}

--- a/z/file_linux.go
+++ b/z/file_linux.go
@@ -1,12 +1,28 @@
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package z
 
 import (
 	"fmt"
 )
 
-// Truncate would truncate the mmapped file to the given size. On Linux and
-// others, we could directly just truncate the underlying file, but in Windows,
-// we can't do that. So, unmap first, then truncate, then re-map.
+// Truncate would truncate the mmapped file to the given size. On Linux, we truncate
+// the underlying file and then call mremap, but on other systems, we unmap first,
+// then truncate, then re-map.
 func (m *MmapFile) Truncate(maxSz int64) error {
 	if err := m.Sync(); err != nil {
 		return fmt.Errorf("while sync file: %s, error: %v\n", m.Fd.Name(), err)


### PR DESCRIPTION
Linux exposes an `mremap` function that is not available on other OSes, that allows us to remap an address space, providing a more efficient way to increase the size of an mmap file. This PR allows Linux systems to use the `mremap` call, while other OSes continue to use `munmap` followed by `mmap`.

`sys` does not provide an `mremap` function, so this had to handwritten using a system call. Unfortunately, the functions provided by `sys` for `Mmap`/`Munmap` maintain a list of active mappings, and do not allow us to `Munmap` anything that is not present in the list. Since our handwritten `mremap` call cannot update that internal list, we must reimplement the `munmap` system call as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/221)
<!-- Reviewable:end -->
