### PR TITLE
Fix(buffer): Expose padding by z.Buffer's APIs and fix test

### DIFF
--- a/z/buffer.go
+++ b/z/buffer.go
@@ -239,17 +239,6 @@ func (b *Buffer) AllocateOffset(n int) int {
 	return int(b.offset) - n
 }
 
-// IncrementOffset returns the incremented offset. This operation is thread-safe. This API should be
-// used carefully. It is NOT used by other methods in this struct.
-// Note: Only this API is thread-safe, the other APIs should not be used concurrently.
-func (b *Buffer) IncrementOffset(n int) int {
-	out := int(atomic.AddUint64(&b.offset, uint64(n)))
-	if out > b.curSz {
-		panic("Buffer size limit hit")
-	}
-	return out
-}
-
 func (b *Buffer) writeLen(sz int) {
 	buf := b.Allocate(4)
 	binary.BigEndian.PutUint32(buf, uint32(sz))

--- a/z/buffer.go
+++ b/z/buffer.go
@@ -236,8 +236,7 @@ func (b *Buffer) Allocate(n int) []byte {
 func (b *Buffer) AllocateOffset(n int) int {
 	b.Grow(n)
 	b.offset += uint64(n)
-	// Remove padding from the offset because the padding should be invisible to the API caller.
-	return int(b.offset) - n - b.StartOffset()
+	return int(b.offset) - n
 }
 
 // IncrementOffset returns the incremented offset. This operation is thread-safe. This API should be
@@ -248,8 +247,7 @@ func (b *Buffer) IncrementOffset(n int) int {
 	if out > b.curSz {
 		panic("Buffer size limit hit")
 	}
-	// Remove padding from the offset because the padding should be invisible to the API caller.
-	return out - b.StartOffset()
+	return out
 }
 
 func (b *Buffer) writeLen(sz int) {
@@ -472,7 +470,7 @@ func (b *Buffer) Data(offset int) []byte {
 	if offset > b.curSz {
 		panic("offset beyond current size")
 	}
-	return b.buf[b.StartOffset()+offset : b.curSz]
+	return b.buf[offset:b.curSz]
 }
 
 // Write would write p bytes to the buffer.

--- a/z/buffer_test.go
+++ b/z/buffer_test.go
@@ -263,8 +263,4 @@ func TestBufferPadding(t *testing.T) {
 	copy(buf.Bytes(), b)
 	data := buf.Data(buf.StartOffset())
 	require.Equal(t, b, data[:sz])
-
-	newOffset := buf.IncrementOffset(int(sz))
-	require.Equal(t, buf.StartOffset()+int(sz+sz), newOffset)
-
 }

--- a/z/buffer_test.go
+++ b/z/buffer_test.go
@@ -249,23 +249,22 @@ func TestBufferSort(t *testing.T) {
 	}
 }
 
-// Test that AllocateOffset and IncrementOffset returns logical
-// offsets, i.e. excludes padding.
+// Test that the APIs returns the expected offsets.
 func TestBufferPadding(t *testing.T) {
 	buf := NewBuffer(1 << 10)
 	sz := rand.Int31n(100)
 
 	writeOffset := buf.AllocateOffset(int(sz))
-	require.Equal(t, 0, writeOffset)
+	require.Equal(t, buf.StartOffset(), writeOffset)
 
 	b := make([]byte, sz)
 	rand.Read(b)
 
 	copy(buf.Bytes(), b)
-	data := buf.Data(0)
+	data := buf.Data(buf.StartOffset())
 	require.Equal(t, b, data[:sz])
 
 	newOffset := buf.IncrementOffset(int(sz))
-	require.Equal(t, int(sz+sz), newOffset)
+	require.Equal(t, buf.StartOffset()+int(sz+sz), newOffset)
 
 }


### PR DESCRIPTION
We need to include the padding in the offsets returned by the APIs because we use zero offset as a check for nil nodes.
It also removes the API `IncrementOffset()` because it was being used only in skiplist and we don't need it anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/222)
<!-- Reviewable:end -->
