### PR TITLE
fix(allocator): increase number of buffers from 32 to 64 in allocator

### DIFF
--- a/z/allocator.go
+++ b/z/allocator.go
@@ -74,7 +74,7 @@ func NewAllocator(sz int) *Allocator {
 	}
 	a := &Allocator{
 		Ref:     ref,
-		buffers: make([][]byte, 32),
+		buffers: make([][]byte, 64),
 	}
 	l2 := uint64(log2(sz))
 	if bits.OnesCount64(uint64(sz)) > 1 {


### PR DESCRIPTION
This PR increases the number of buffers from 32 to 64 in z.Allocator.
Related discuss issue: https://discuss.dgraph.io/t/panic-allocator-can-not-allocate-more-than-32-buffers/11650
The following test crashes even at `~13GB` allocator size.
```go
func TestAllocatorIdx(t *testing.T) {
	a := NewAllocator(512)
	sz := 512
	defer a.Release()
	for i := 0; i < 40; i++ {
		x := a.Allocate(sz)
                // mimic how allocator allocates
		if sz < 1<<30 {
			sz = 2 * sz
		}
		rand.Read(x)
		fmt.Printf("%s\n", a)
	}
}
```
Failure message
```
idx: 29 len: 1073741824 cum: 10737417728
idx: 30 len: 1073741824 cum: 11811159552
idx: 31 len: 1073741824 cum: 12884901376
bi: 31 pi: 1073741824
Size: 12884901376

--- FAIL: TestAllocatorIdx (10.40s)
panic: Allocator can not allocate more than 32 buffers [recovered]
	panic: Allocator can not allocate more than 32 buffers
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/234)
<!-- Reviewable:end -->
