### PR TITLE
fix(jemalloc): Fix the stats of jemalloc

### DIFF
--- a/contrib/memtest/main.go
+++ b/contrib/memtest/main.go
@@ -33,6 +33,7 @@ import (
 	"unsafe"
 
 	"github.com/dgraph-io/ristretto/z"
+	"github.com/dustin/go-humanize"
 )
 
 type S struct {
@@ -109,8 +110,16 @@ func memory() {
 			counter++
 		}
 	}
-	fmt.Printf("[%d] Current Memory: %05.2f G. Increase? %v\n",
-		counter, float64(curMem)/float64(1<<30), increase)
+	var js z.MemStats
+	z.ReadMemStats(&js)
+
+	fmt.Printf("[%d] Current Memory: %s. Increase? %v, MemStats [Active: %s, Allocated: %s,"+
+		" Resident%s, Retained: %s]\n",
+		counter,
+		humanize.IBytes(uint64(z.NumAllocBytes())),
+		increase,
+		humanize.IBytes(js.Active), humanize.IBytes(js.Allocated),
+		humanize.IBytes(js.Resident), humanize.IBytes(js.Retained))
 }
 
 func viaLL() {

--- a/contrib/memtest/main.go
+++ b/contrib/memtest/main.go
@@ -115,7 +115,7 @@ func memory() {
 
 	fmt.Printf("[%d] Current Memory: %s. Increase? %v, MemStats [Active: %s, Allocated: %s,"+
 		" Resident: %s, Retained: %s]\n",
-		counter, humanize.IBytes(uint64(z.NumAllocBytes())), increase,
+		counter, humanize.IBytes(uint64(curMem)), increase,
 		humanize.IBytes(js.Active), humanize.IBytes(js.Allocated),
 		humanize.IBytes(js.Resident), humanize.IBytes(js.Retained))
 }

--- a/contrib/memtest/main.go
+++ b/contrib/memtest/main.go
@@ -114,10 +114,8 @@ func memory() {
 	z.ReadMemStats(&js)
 
 	fmt.Printf("[%d] Current Memory: %s. Increase? %v, MemStats [Active: %s, Allocated: %s,"+
-		" Resident%s, Retained: %s]\n",
-		counter,
-		humanize.IBytes(uint64(z.NumAllocBytes())),
-		increase,
+		" Resident: %s, Retained: %s]\n",
+		counter, humanize.IBytes(uint64(z.NumAllocBytes())), increase,
 		humanize.IBytes(js.Active), humanize.IBytes(js.Allocated),
 		humanize.IBytes(js.Resident), humanize.IBytes(js.Retained))
 }

--- a/z/calloc_jemalloc.go
+++ b/z/calloc_jemalloc.go
@@ -158,6 +158,10 @@ func ReadMemStats(stats *MemStats) {
 	if stats == nil {
 		return
 	}
+	// Call an epoch mallclt to refresh the stats data as mentioned in the docs.
+	// http://jemalloc.net/jemalloc.3.html#epoch
+	// Note: This epoch mallctl is as expensive as a malloc call. It takes up the
+	// malloc_mutex_lock.
 	epoch := 1
 	sz := unsafe.Sizeof(&epoch)
 	C.je_mallctl(

--- a/z/calloc_jemalloc.go
+++ b/z/calloc_jemalloc.go
@@ -158,6 +158,14 @@ func ReadMemStats(stats *MemStats) {
 	if stats == nil {
 		return
 	}
+	epoch := 1
+	sz := unsafe.Sizeof(&epoch)
+	C.je_mallctl(
+		(C.CString)("epoch"),
+		unsafe.Pointer(&epoch),
+		(*C.size_t)(unsafe.Pointer(&sz)),
+		unsafe.Pointer(&epoch),
+		(C.size_t)(unsafe.Sizeof(epoch)))
 	stats.Allocated = fetchStat("stats.allocated")
 	stats.Active = fetchStat("stats.active")
 	stats.Resident = fetchStat("stats.resident")


### PR DESCRIPTION
The jemalloc stats are read by using the `mallctl()` call, this call doesn't return the latest stats unless we refresh the ctl cache. We can get the latest stats after calling an epoch mallctl. This PR fixes this issue.

**Note: Calling an epoch mallctl is expensive. An epoch mallctl takes up all the locks as taken by a malloc call. We should use this judiciously.**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/236)
<!-- Reviewable:end -->
