### PR TITLE
Add feature to be able to list cached keys

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -38,7 +38,7 @@ var (
 
 type itemCallback func(*Item)
 
-const itemSize = int64(unsafe.Sizeof(storeItem{}))
+const itemSize = int64(unsafe.Sizeof(storeItem{})) // skipcq: GSC-G103
 
 // Cache is a thread-safe implementation of a hashmap with a TinyLFU admission
 // policy and a Sampled LFU eviction policy. You can use the same Cache instance

--- a/cache_test.go
+++ b/cache_test.go
@@ -865,3 +865,34 @@ func newTestCache() (*Cache, error) {
 		Metrics:     true,
 	})
 }
+
+func TestCache_ListKeys(t *testing.T) {
+	newKey := "newKey"
+
+	c, err := newTestCache()
+	require.NoError(t, err)
+	require.True(t, c.keySaver == nil)
+	require.True(t, len(c.ListKeys()) == 0)
+	c.SetWithTTL(newKey, 1, 1, 10 * time.Second)
+	require.True(t, len(c.ListKeys()) == 0)
+
+	c, err = NewCache(&Config{
+		NumCounters:        100,
+		MaxCost:            10,
+		IgnoreInternalCost: true,
+		BufferItems:        64,
+		Metrics:            true,
+		EnableKeySaver:     true,
+	})
+	require.NoError(t, err)
+	require.True(t, c.keySaver != nil)
+
+	c.keySaver.AddKey(newKey)
+	require.True(t, len(c.ListKeys()) == 1)
+	c.keySaver.DelKey("nonexistent")
+	require.True(t, len(c.ListKeys()) == 1)
+	c.keySaver.DelKey(newKey)
+	require.True(t, len(c.ListKeys()) == 0)
+	c.SetWithTTL(newKey, 1, 1, 10 * time.Second)
+	require.True(t, len(c.ListKeys()) == 1)
+}

--- a/key.go
+++ b/key.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Ristretto is a fast, fixed size, in-memory cache with a dual focus on
+// throughput and hit ratio performance. You can easily add Ristretto to an
+// existing system and keep the most valuable data where you need it.
+package ristretto
+
+import "sync"
+
+// ClearKey contains an array referencing the keys saved in the Ristretto
+// cache and implements Mutex to ensure the array didn't get updated during
+// inspection or update. It ensure deadlocks or any crash won't happen.
+type ClearKey struct {
+	keys map[string]string
+	mu sync.RWMutex
+}
+
+// NewClearKey generate a new ClearKey object and returns it
+func NewClearKey() *ClearKey {
+	ck := &ClearKey{}
+	ck.keys = make(map[string]string)
+	return ck
+}
+
+// ListKeys returns the saved keys list to the client.
+func (c *ClearKey) ListKeys() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	keys := make([]string, 0, len(c.keys))
+	for k := range c.keys {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// AddKey is called to update keys array with non-existing key or replacing
+// the existing one.
+func (c *ClearKey) AddKey(key string) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	c.keys[key] = ""
+}
+
+// DelKey is called to delete a key if exists, it does nothing otherwise
+func (c *ClearKey) DelKey(key string) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	delete(c.keys, key)
+}

--- a/key_test.go
+++ b/key_test.go
@@ -1,0 +1,56 @@
+package ristretto
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestNewClearKey(t *testing.T) {
+	c := NewClearKey()
+	require.True(t, c != nil)
+	require.True(t, len(c.keys) == 0)
+}
+
+func TestClearKey_AddKey(t *testing.T) {
+	c := NewClearKey()
+	c.AddKey("newKey")
+	c.AddKey("anotherKey")
+	require.True(t, len(c.keys) == 2)
+}
+
+func TestClearKey_ListKeys(t *testing.T) {
+	firstKey := "firstKey"
+	secondKey := "secondKey"
+
+	c := NewClearKey()
+	c.AddKey(firstKey)
+	c.AddKey(secondKey)
+	require.True(t, len(c.ListKeys()) == 2)
+	require.True(t, c.ListKeys()[0] == firstKey)
+	require.True(t, c.ListKeys()[1] == secondKey)
+}
+
+func TestClearKey_DelKey(t *testing.T) {
+	firstKey := "firstKey"
+	secondKey := "secondKey"
+	thirdKey := "thirdKey"
+
+	c := NewClearKey()
+	c.AddKey(firstKey)
+	c.AddKey(secondKey)
+	c.AddKey(thirdKey)
+
+	c.DelKey(secondKey)
+	listKey := c.ListKeys()
+	require.True(t, len(listKey) == 2)
+	require.True(t, listKey[0] == firstKey)
+	require.True(t, listKey[1] == thirdKey)
+
+	c.DelKey(firstKey)
+	require.True(t, len(c.ListKeys()) == 1)
+	require.True(t, c.ListKeys()[0] == thirdKey)
+
+	c.DelKey("nonexistent")
+	require.True(t, len(c.ListKeys()) == 1)
+	require.True(t, c.ListKeys()[0] == thirdKey)
+}


### PR DESCRIPTION
Hi, for a side-project (a cache system called [Souin](https://github.com/darkweak/Souin)), I'm planning to expose the cached keys through a REST API
Then I need the feature to list them. Due to the hashed keys I couldn't retrieve corresponding keys, then I choose to store keys before hashing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/243)
<!-- Reviewable:end -->
