### PR TITLE
fix(windows): use filepath instead of path

### DIFF
--- a/z/file.go
+++ b/z/file.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 )
@@ -60,7 +60,7 @@ func OpenMmapFileUsing(fd *os.File, sz int, writable bool) (*MmapFile, error) {
 	}
 
 	if fileSize == 0 {
-		dir, _ := path.Split(filename)
+		dir, _ := filepath.Split(filename)
 		go SyncDir(dir)
 	}
 	return &MmapFile{


### PR DESCRIPTION
`path` package is not for windows, we should use `path/filepath` instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/244)
<!-- Reviewable:end -->
