### PR TITLE
Fix incorrect unit test coverage depiction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ristretto
 [![Go Doc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/dgraph-io/ristretto)
 [![Go Report Card](https://img.shields.io/badge/go%20report-A%2B-brightgreen)](https://goreportcard.com/report/github.com/dgraph-io/ristretto)
-[![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://gocover.io/github.com/dgraph-io/ristretto)
+[![Coverage](https://gocover.io/_badge/github.com/dgraph-io/ristretto)](https://gocover.io/github.com/dgraph-io/ristretto)
 ![Tests](https://github.com/dgraph-io/ristretto/workflows/tests/badge.svg)
 
 Ristretto is a fast, concurrent cache library built with a focus on performance and correctness.


### PR DESCRIPTION
Unit test coverage report from gocover suggests a 71% test coverage but the current badge depicts 100% test coverage, which isn't the case. This fixes the badge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/245)
<!-- Reviewable:end -->
