### PR TITLE
structure alignment for 386

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -279,9 +279,15 @@ func (p *defaultPolicy) UpdateMaxCost(maxCost int64) {
 
 // sampledLFU is an eviction helper storing key-cost pairs.
 type sampledLFU struct {
-	keyCosts map[uint64]int64
+	// NOTE: align maxCost to 64-bit boundary for use with atomic.
+	// As per https://golang.org/pkg/sync/atomic/: "On ARM, x86-32,
+	// and 32-bit MIPS, it is the caller’s responsibility to arrange
+	// for 64-bit alignment of 64-bit words accessed atomically.
+	// The first word in a variable or in an allocated struct, array,
+	// or slice can be relied upon to be 64-bit aligned."
 	maxCost  int64
 	used     int64
+	keyCosts map[uint64]int64
 	metrics  *Metrics
 }
 


### PR DESCRIPTION
This is a fix for a panic on 386 caused by int64 mis-alignment on 386.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/249)
<!-- Reviewable:end -->
