### PR TITLE
replace RWMutex-map with skipmap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,6 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.4.0
+	github.com/zhangyunhao116/skipmap v0.1.1
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,6 @@ github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -19,6 +18,12 @@ github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasO
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/zhangyunhao116/sbconv v0.2.1 h1:9Z43QFpnkYNjCrRz8UR9ShVRVQ0OG5VtLKQ3mAL5zjU=
+github.com/zhangyunhao116/sbconv v0.2.1/go.mod h1:pdAXGnJGNM68XNdJOfGCelkEHgrQMWSeW/2/qKjuiQQ=
+github.com/zhangyunhao116/skipmap v0.1.1 h1:P1EwRYei51ySEkvDNwoYCl1m2ODcdvesgAXUiT0R7xU=
+github.com/zhangyunhao116/skipmap v0.1.1/go.mod h1:VxyysCe3PeCNduuzkwhIufv7DArV2PNG9hC7IJZxZBY=
+github.com/zhangyunhao116/wyhash v0.3.2 h1:v2VfcnTCLWv0mjFNg6t2EcZAj8Y91fG7Vb004xHauXI=
+github.com/zhangyunhao116/wyhash v0.3.2/go.mod h1:9okT6cr1VZK9N3Tv0I6qUYDNtQgOfcQgfMRCEXt9d8I=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/store_test.go
+++ b/store_test.go
@@ -119,13 +119,11 @@ func TestStoreUpdate(t *testing.T) {
 
 func TestStoreCollision(t *testing.T) {
 	s := newShardedMap()
-	s.shards[1].Lock()
-	s.shards[1].data[1] = storeItem{
+	s.shards[1].data().Store(1, storeItem{
 		key:      1,
 		conflict: 0,
 		value:    1,
-	}
-	s.shards[1].Unlock()
+	})
 	val, ok := s.Get(1, 1)
 	require.False(t, ok)
 	require.Nil(t, val)


### PR DESCRIPTION
Yesterday i saw an interesting article(https://dgraph.io/blog/post/introducing-ristretto-high-perf-go-cache/), i am faced with the same problem before, so i develop a high-performance map called `skipmap`(https://github.com/zhangyunhao116/skipmap).

Here is an alternative choice that replace `RWMutex-map` with `skipmap `.
```
name                old time/op    new time/op    delta
SketchIncrement-16    8.22ns ± 0%    8.24ns ± 1%      ~     (p=0.118 n=9+9)
SketchEstimate-16     8.35ns ± 1%    8.40ns ± 0%    +0.55%  (p=0.043 n=10+8)
StoreGet-16           34.6ns ± 0%    14.4ns ± 6%   -58.52%  (p=0.000 n=9+10)
StoreSet-16            396ns ± 2%     545ns ± 2%   +37.66%  (p=0.000 n=10+10)
StoreUpdate-16         410ns ± 2%     547ns ± 1%   +33.48%  (p=0.000 n=10+8)

name                old speed      new speed      delta
SketchIncrement-16   122MB/s ± 0%   121MB/s ± 1%      ~     (p=0.130 n=9+9)
SketchEstimate-16    120MB/s ± 1%   119MB/s ± 0%    -0.55%  (p=0.043 n=10+8)
StoreGet-16         28.9MB/s ± 0%  69.7MB/s ± 7%  +141.33%  (p=0.000 n=9+10)
StoreSet-16         2.53MB/s ± 2%  1.83MB/s ± 2%   -27.46%  (p=0.000 n=10+10)
StoreUpdate-16      2.44MB/s ± 1%  1.83MB/s ± 1%   -25.24%  (p=0.000 n=9+8)
```

The benchmark contains 100% Get or 100%Set, but usually, we often perform 50%Get50%Set, 30%Set70%Get, etc. the `skipmap` is a good choice for these situations, we can see the benchmark in https://github.com/zhangyunhao116/skipmap#benchmark

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/250)
<!-- Reviewable:end -->
