### PR TITLE
SuperFlagHelp keep newline if defaults non-empty

### DIFF
--- a/z/flags.go
+++ b/z/flags.go
@@ -69,7 +69,15 @@ func (h *SuperFlagHelp) String() string {
 	sort.Strings(otherLines)
 	dls := strings.Join(defaultLines, "")
 	ols := strings.Join(otherLines, "")
-	return h.head + "\n" + dls + ols[:len(ols)-1] // remove last newline
+	if len(ols) == 0 {
+		// remove last newline
+		dls = dls[:len(dls)-1]
+	}
+	// remove last newline
+	if len(ols) > 1 {
+		ols = ols[:len(ols)-1]
+	}
+	return h.head + "\n" + dls + ols
 }
 
 func parseFlag(flag string) map[string]string {

--- a/z/flags.go
+++ b/z/flags.go
@@ -69,12 +69,12 @@ func (h *SuperFlagHelp) String() string {
 	sort.Strings(otherLines)
 	dls := strings.Join(defaultLines, "")
 	ols := strings.Join(otherLines, "")
-	if len(ols) == 0 {
+	if len(h.defaults.m) == 0 && len(ols) == 0 {
 		// remove last newline
 		dls = dls[:len(dls)-1]
 	}
 	// remove last newline
-	if len(ols) > 1 {
+	if len(h.defaults.m) == 0 && len(ols) > 1 {
 		ols = ols[:len(ols)-1]
 	}
 	return h.head + "\n" + dls + ols


### PR DESCRIPTION
Before (default string not on newline):

```
--vault string                 Vault options (defaults shown):
                                     addr=http://localhost:8200; Vault server address in the form of http://ip:port
                                     field=enc_key; Vault kv store field whose value is the base64 encoded encryption key.
                                     format=base64; Vault field format: raw or base64.
                                     path=secret/data/dgraph; Vault kv store path. e.g. secret/data/dgraph for kv-v2, kv/dgraph for kv-v1.
                                     role-id-file=; File containing Vault role-id used for approle auth.
                                     secret-id-file=; File containing Vault secret-id used for approle auth. (default "addr=http://localhost:8200; path=secret/data/dgraph; field=enc_key; format=base64;")
```

After:

```
--vault string                 Vault options (defaults shown):
                                     addr=http://localhost:8200; Vault server address in the form of http://ip:port
                                     field=enc_key; Vault kv store field whose value is the base64 encoded encryption key.
                                     format=base64; Vault field format: raw or base64.
                                     path=secret/data/dgraph; Vault kv store path. e.g. secret/data/dgraph for kv-v2, kv/dgraph for kv-v1.
                                     role-id-file=; File containing Vault role-id used for approle auth.
                                     secret-id-file=; File containing Vault secret-id used for approle auth. 
                                   (default "addr=http://localhost:8200; path=secret/data/dgraph; field=enc_key; format=base64;")
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/253)
<!-- Reviewable:end -->
