### PR TITLE
chore(perf): using tags instead of runtime callers to improve the performance of leak detection

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -801,7 +801,7 @@ func TestRistrettoCalloc(t *testing.T) {
 			rd := rand.New(rand.NewSource(time.Now().UnixNano()))
 			for i := 0; i < 10000; i++ {
 				k := rd.Intn(10000)
-				v := z.Calloc(256)
+				v := z.Calloc(256, "test")
 				rd.Read(v)
 				if !r.Set(k, v, 256) {
 					z.Free(v)
@@ -841,7 +841,7 @@ func TestRistrettoCallocTTL(t *testing.T) {
 			rd := rand.New(rand.NewSource(time.Now().UnixNano()))
 			for i := 0; i < 10000; i++ {
 				k := rd.Intn(10000)
-				v := z.Calloc(256)
+				v := z.Calloc(256, "test")
 				rd.Read(v)
 				if !r.SetWithTTL(k, v, 256, time.Second) {
 					z.Free(v)

--- a/contrib/demo/node_allocator.go
+++ b/contrib/demo/node_allocator.go
@@ -10,7 +10,7 @@ import (
 
 // Defined in node.go.
 func init() {
-	alloc = z.NewAllocator(10 << 20)
+	alloc = z.NewAllocator(10 << 20, "demo")
 }
 
 func newNode(val int) *node {

--- a/contrib/demo/node_jemalloc.go
+++ b/contrib/demo/node_jemalloc.go
@@ -9,7 +9,7 @@ import (
 )
 
 func newNode(val int) *node {
-	b := z.Calloc(nodeSz)
+	b := z.Calloc(nodeSz, "demo")
 	n := (*node)(unsafe.Pointer(&b[0]))
 	n.val = val
 	return n

--- a/contrib/memtest/withjemalloc.go
+++ b/contrib/memtest/withjemalloc.go
@@ -8,12 +8,12 @@ import (
 	"github.com/dgraph-io/ristretto/z"
 )
 
-func Calloc(size int) []byte { return z.Calloc(size) }
+func Calloc(size int) []byte { return z.Calloc(size, "memtest") }
 func Free(bs []byte)         { z.Free(bs) }
 func NumAllocBytes() int64   { return z.NumAllocBytes() }
 
 func check() {
-	if buf := z.CallocNoRef(1); len(buf) == 0 {
+	if buf := z.CallocNoRef(1, "memtest"); len(buf) == 0 {
 		log.Fatalf("Not using manual memory management. Compile with jemalloc.")
 	} else {
 		z.Free(buf)

--- a/z/allocator.go
+++ b/z/allocator.go
@@ -333,6 +333,7 @@ func (p *AllocatorPool) Get(sz int, tag string) *Allocator {
 	select {
 	case alloc := <-p.allocCh:
 		alloc.Reset()
+		alloc.Tag = tag
 		return alloc
 	default:
 		return NewAllocator(sz, tag)

--- a/z/allocator.go
+++ b/z/allocator.go
@@ -66,7 +66,7 @@ func init() {
 }
 
 // NewAllocator creates an allocator starting with the given size.
-func NewAllocator(sz int) *Allocator {
+func NewAllocator(sz int, tag string) *Allocator {
 	ref := atomic.AddUint64(&allocRef, 1)
 	// We should not allow a zero sized page because addBufferWithMinSize
 	// will run into an infinite loop trying to double the pagesize.
@@ -76,12 +76,13 @@ func NewAllocator(sz int) *Allocator {
 	a := &Allocator{
 		Ref:     ref,
 		buffers: make([][]byte, 64),
+		Tag:     tag,
 	}
 	l2 := uint64(log2(sz))
 	if bits.OnesCount64(uint64(sz)) > 1 {
 		l2 += 1
 	}
-	a.buffers[0] = Calloc(1 << l2)
+	a.buffers[0] = Calloc(1<<l2, a.Tag)
 
 	allocsMu.Lock()
 	allocs[ref] = a
@@ -271,7 +272,7 @@ func (a *Allocator) addBufferAt(bufIdx, minSz int) {
 		pageSize = maxAlloc
 	}
 
-	buf := Calloc(pageSize)
+	buf := Calloc(pageSize, a.Tag)
 	assert(len(a.buffers[bufIdx]) == 0)
 	a.buffers[bufIdx] = buf
 }
@@ -324,9 +325,9 @@ func NewAllocatorPool(sz int) *AllocatorPool {
 	return a
 }
 
-func (p *AllocatorPool) Get(sz int) *Allocator {
+func (p *AllocatorPool) Get(sz int, tag string) *Allocator {
 	if p == nil {
-		return NewAllocator(sz)
+		return NewAllocator(sz, tag)
 	}
 	atomic.AddInt64(&p.numGets, 1)
 	select {
@@ -334,7 +335,7 @@ func (p *AllocatorPool) Get(sz int) *Allocator {
 		alloc.Reset()
 		return alloc
 	default:
-		return NewAllocator(sz)
+		return NewAllocator(sz, tag)
 	}
 }
 func (p *AllocatorPool) Return(a *Allocator) {

--- a/z/allocator_test.go
+++ b/z/allocator_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestAllocate(t *testing.T) {
-	a := NewAllocator(1024)
+	a := NewAllocator(1024, "test")
 	defer a.Release()
 
 	check := func() {
@@ -51,17 +51,17 @@ func TestAllocate(t *testing.T) {
 }
 
 func TestAllocateSize(t *testing.T) {
-	a := NewAllocator(1024)
+	a := NewAllocator(1024, "test")
 	require.Equal(t, 1024, len(a.buffers[0]))
 	a.Release()
 
-	b := NewAllocator(1025)
+	b := NewAllocator(1025, "test")
 	require.Equal(t, 2048, len(b.buffers[0]))
 	b.Release()
 }
 
 func TestAllocateReset(t *testing.T) {
-	a := NewAllocator(16)
+	a := NewAllocator(16, "test")
 	defer a.Release()
 
 	buf := make([]byte, 128)
@@ -80,7 +80,7 @@ func TestAllocateReset(t *testing.T) {
 }
 
 func TestAllocateTrim(t *testing.T) {
-	a := NewAllocator(16)
+	a := NewAllocator(16, "test")
 	defer a.Release()
 
 	buf := make([]byte, 128)
@@ -108,7 +108,7 @@ func TestPowTwo(t *testing.T) {
 }
 
 func TestAllocateAligned(t *testing.T) {
-	a := NewAllocator(1024)
+	a := NewAllocator(1024, "test")
 	defer a.Release()
 
 	a.Allocate(1)
@@ -126,7 +126,7 @@ func TestAllocateAligned(t *testing.T) {
 }
 
 func TestAllocateConcurrent(t *testing.T) {
-	a := NewAllocator(63)
+	a := NewAllocator(63, "test")
 	defer a.Release()
 
 	N := 10240
@@ -180,7 +180,7 @@ func TestAllocateConcurrent(t *testing.T) {
 }
 
 func BenchmarkAllocate(b *testing.B) {
-	a := NewAllocator(15)
+	a := NewAllocator(15, "test")
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			buf := a.Allocate(1)

--- a/z/buffer_test.go
+++ b/z/buffer_test.go
@@ -38,7 +38,7 @@ func TestBuffer(t *testing.T) {
 			var bytesBuffer bytes.Buffer // This is just for verifying result.
 			bytesBuffer.Grow(512)
 
-			cBuffer, err := NewBufferWith(512, 4<<30, btype)
+			cBuffer, err := NewBufferWith(512, 4<<30, btype, "test")
 			require.Nil(t, err)
 			defer cBuffer.Release()
 
@@ -71,7 +71,7 @@ func TestBufferWrite(t *testing.T) {
 			var wb [128]byte
 			rand.Read(wb[:])
 
-			cb, err := NewBufferWith(32, 4<<30, btype)
+			cb, err := NewBufferWith(32, 4<<30, btype, "test")
 			require.Nil(t, err)
 			defer cb.Release()
 
@@ -94,7 +94,7 @@ func TestBufferWrite(t *testing.T) {
 }
 
 func TestBufferAutoMmap(t *testing.T) {
-	buf := NewBuffer(1 << 20)
+	buf := NewBuffer(1 << 20, "test")
 	defer buf.Release()
 	buf.AutoMmapAfter(64 << 20)
 
@@ -124,7 +124,7 @@ func TestBufferAutoMmap(t *testing.T) {
 }
 
 func TestBufferSimpleSort(t *testing.T) {
-	buf := NewBuffer(1 << 20)
+	buf := NewBuffer(1 << 20, "test")
 	defer buf.Release()
 	for i := 0; i < 25600; i++ {
 		b := buf.SliceAllocate(4)
@@ -154,7 +154,7 @@ func TestBufferSlice(t *testing.T) {
 	for btype := UseCalloc; btype < UseInvalid; btype++ {
 		name := fmt.Sprintf("Using mode %s", btype)
 		t.Run(name, func(t *testing.T) {
-			buf, err := NewBufferWith(0, 0, btype)
+			buf, err := NewBufferWith(0, 0, btype, "test")
 			require.Nil(t, err)
 			defer buf.Release()
 
@@ -209,7 +209,7 @@ func TestBufferSort(t *testing.T) {
 	for btype := UseCalloc; btype < UseInvalid; btype++ {
 		name := fmt.Sprintf("Using mode %s", btype)
 		t.Run(name, func(t *testing.T) {
-			buf, err := NewBufferWith(0, 0, btype)
+			buf, err := NewBufferWith(0, 0, btype, "test")
 			require.Nil(t, err)
 			defer buf.Release()
 
@@ -252,7 +252,7 @@ func TestBufferSort(t *testing.T) {
 
 // Test that the APIs returns the expected offsets.
 func TestBufferPadding(t *testing.T) {
-	buf := NewBuffer(1 << 10)
+	buf := NewBuffer(1 << 10, "test")
 	defer buf.Release()
 	sz := rand.Int31n(100)
 

--- a/z/calloc_jemalloc.go
+++ b/z/calloc_jemalloc.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-// +build !jemalloc
+// +build jemalloc
 
 package z
 

--- a/z/calloc_jemalloc.go
+++ b/z/calloc_jemalloc.go
@@ -89,11 +89,13 @@ func Calloc(n int) []byte {
 		var pc [50]uintptr
 		n := runtime.Callers(2, pc[:])
 		frames := runtime.CallersFrames(pc[:n])
-		for {
-			frame, more := frames.Next()
-			if !more {
-				break
-			}
+		more := true
+		var frame runtime.Frame
+		for more {
+			// more will be false, when there are no frames, though the frame
+			// will be valid value in that case. In this way we will analyze
+			// the frame and exit the loop at the same time.
+			frame, more = frames.Next()
 			if strings.Contains(frame.File, "/ristretto") {
 				continue
 			}

--- a/z/calloc_nojemalloc.go
+++ b/z/calloc_nojemalloc.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-// +build !jemalloc !cgo
+// +build jemalloc !cgo
 
 package z
 
@@ -14,12 +14,12 @@ import (
 // (eg: build without jemalloc tag).
 
 // Calloc allocates a slice of size n.
-func Calloc(n int) []byte {
+func Calloc(n int, tag string) []byte {
 	return make([]byte, n)
 }
 
 // CallocNoRef will not give you memory back without jemalloc.
-func CallocNoRef(n int) []byte {
+func CallocNoRef(n int, tag string) []byte {
 	// We do the add here just to stay compatible with a corresponding Free call.
 	return nil
 }

--- a/z/calloc_nojemalloc.go
+++ b/z/calloc_nojemalloc.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-// +build jemalloc !cgo
+// +build !jemalloc !cgo
 
 package z
 

--- a/z/calloc_test.go
+++ b/z/calloc_test.go
@@ -68,7 +68,7 @@ func BenchmarkAllocation(b *testing.B) {
 			r := rand.New(source)
 			for pb.Next() {
 				sz := r.Intn(100) << 10
-				x := Calloc(sz)
+				x := Calloc(sz, "test")
 				r.Read(x)
 				Free(x)
 			}
@@ -81,16 +81,16 @@ func TestCalloc(t *testing.T) {
 	// JE_MALLOC_CONF="abort:true,tcache:false"
 
 	StatsPrint()
-	buf := CallocNoRef(1)
+	buf := CallocNoRef(1, "test")
 	if len(buf) == 0 {
 		t.Skipf("Not using jemalloc. Skipping test.")
 	}
 	Free(buf)
 	require.Equal(t, int64(0), NumAllocBytes())
 
-	buf1 := Calloc(128)
+	buf1 := Calloc(128, "test")
 	require.Equal(t, int64(128), NumAllocBytes())
-	buf2 := Calloc(128)
+	buf2 := Calloc(128, "test")
 	require.Equal(t, int64(256), NumAllocBytes())
 
 	Free(buf1)


### PR DESCRIPTION
Earlier we used to loop over the caller function stack to find out who requested the memory. In this way it leads to multiple runtime.Caller calls that are expensive. Internally, runtime.Caller collects the full stack trace and then resolve the current callee function. We skipped this loop and get all the information(limit of 50, we can make this small though). Then we check for non-ristretto function among the complete stacktrace thus saving multiple runtime.Callers call. This should enhance the performance of calloc directly in the ratio of depth we have in the Calloc stack trace for the non-ristretto function.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/255)
<!-- Reviewable:end -->
