### PR TITLE
fix (build): build search.go for all architectures except amd64

### DIFF
--- a/z/simd/search.go
+++ b/z/simd/search.go
@@ -1,4 +1,4 @@
-// +build 386 arm armbe arm64 mips mipsle mips64p32 mips64p32le ppc ppc64 ppc64le sparc
+// +build 386 arm armbe arm64 mips mipsle mips64p32 mips64p32le ppc ppc64 ppc64le sparc mips64 mips64le
 
 /*
  * Copyright 2020 Dgraph Labs, Inc. and Contributors

--- a/z/simd/search.go
+++ b/z/simd/search.go
@@ -1,4 +1,4 @@
-// +build 386 arm armbe arm64 mips mipsle mips64p32 mips64p32le ppc ppc64 ppc64le sparc mips64 mips64le
+// +build !amd64
 
 /*
  * Copyright 2020 Dgraph Labs, Inc. and Contributors


### PR DESCRIPTION
Fix build for mips64 and mips64le

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/257)
<!-- Reviewable:end -->
