### PR TITLE
feat(super-flags): Add GetPath method in superflags

### DIFF
--- a/z/flags.go
+++ b/z/flags.go
@@ -259,13 +259,13 @@ func (sf *SuperFlag) GetPath(opt string) string {
 	return path
 }
 
-// expandPath expands the paths containing ~ to /home/user. It also computes the ablosule path
+// expandPath expands the paths containing ~ to /home/user. It also computes the absolute path
 // from the relative paths. For example: ~/abc/../cef will be transformed to /home/user/cef.
 func expandPath(path string) (string, error) {
 	if len(path) == 0 {
 		return "", nil
 	}
-	if path[0] == '~' {
+	if path[0] == '~' && (len(path) == 1 || path[1] == '/') {
 		usr, err := user.Current()
 		if err != nil {
 			return "", errors.Wrap(err, "Failed to get the home directory of the user")

--- a/z/flags.go
+++ b/z/flags.go
@@ -3,6 +3,7 @@ package z
 import (
 	"fmt"
 	"log"
+	"os"
 	"os/user"
 	"path/filepath"
 	"sort"
@@ -265,7 +266,7 @@ func expandPath(path string) (string, error) {
 	if len(path) == 0 {
 		return "", nil
 	}
-	if path[0] == '~' && (len(path) == 1 || path[1] == '/') {
+	if path[0] == '~' && (len(path) == 1 || os.IsPathSeparator(path[1])) {
 		usr, err := user.Current()
 		if err != nil {
 			return "", errors.Wrap(err, "Failed to get the home directory of the user")

--- a/z/flags_test.go
+++ b/z/flags_test.go
@@ -2,6 +2,7 @@ package z
 
 import (
 	"fmt"
+	"os"
 	"os/user"
 	"path/filepath"
 	"testing"
@@ -48,6 +49,8 @@ func TestGetPath(t *testing.T) {
 	usr, err := user.Current()
 	require.NoError(t, err)
 	homeDir := usr.HomeDir
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
 
 	tests := []struct {
 		path     string
@@ -68,6 +71,10 @@ func TestGetPath(t *testing.T) {
 		{
 			"~/",
 			homeDir,
+		},
+		{
+			"~filename",
+			filepath.Join(cwd, "~filename"),
 		},
 	}
 

--- a/z/flags_test.go
+++ b/z/flags_test.go
@@ -1,6 +1,9 @@
 package z
 
 import (
+	"fmt"
+	"os/user"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -34,4 +37,45 @@ func TestFlag(t *testing.T) {
 	require.Equal(t, time.Minute*15, sf.GetDuration("duration-minutes"))
 	require.Equal(t, time.Hour*12, sf.GetDuration("duration-hours"))
 	require.Equal(t, time.Hour*24*30, sf.GetDuration("duration-days"))
+}
+
+func TestGetPath(t *testing.T) {
+
+	usr, err := user.Current()
+	require.NoError(t, err)
+	homeDir := usr.HomeDir
+
+	tests := []struct {
+		path     string
+		expected string
+	}{
+		{
+			"/home/user/file.txt",
+			"/home/user/file.txt",
+		},
+		{
+			"~/file.txt",
+			filepath.Join(homeDir, "file.txt"),
+		},
+		{
+			"~/abc/../file.txt",
+			filepath.Join(homeDir, "file.txt"),
+		},
+		{
+			"~/",
+			homeDir,
+		},
+	}
+
+	get := func(p string) string {
+		opt := fmt.Sprintf("file=%s", p)
+		sf := NewSuperFlag(opt)
+		return sf.GetPath("file")
+	}
+
+	for _, tc := range tests {
+		actual := get(tc.path)
+		require.Equalf(t, tc.expected, actual, "Filed on testcase: %s", tc.path)
+	}
+
 }

--- a/z/flags_test.go
+++ b/z/flags_test.go
@@ -79,6 +79,6 @@ func TestGetPath(t *testing.T) {
 
 	for _, tc := range tests {
 		actual := get(tc.path)
-		require.Equalf(t, tc.expected, actual, "Filed on testcase: %s", tc.path)
+		require.Equalf(t, tc.expected, actual, "Failed on testcase: %s", tc.path)
 	}
 }


### PR DESCRIPTION
In super-flags, the file-paths are given within quotes. So the shell is not able to expand the paths having `~` to `/home/user/...`.
This PR adds `GetPath()` method on super flags which expands the paths having `~` to `/home/user/..`.

For example:
`dgraph alpha --acl="secret_file=~/hmac-secret"` 

the above command throws an error that path doesn't exists even if it exists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/258)
<!-- Reviewable:end -->
