### PR TITLE
fix(superflags): Check for keys without values

### DIFF
--- a/z/flags_test.go
+++ b/z/flags_test.go
@@ -8,20 +8,18 @@ import (
 )
 
 func TestFlag(t *testing.T) {
-	opt := `bool_key=true; int-key=5; float-key=0.05; string_key=value; ;`
-	sf := NewSuperFlag(opt)
-	t.Logf("Got SuperFlag: %s\n", sf)
-
-	def := `bool_key=false; int-key=0; float-key=1.0; string-key=; other-key=5;
+	const opt = `bool_key=true; int-key=5; float-key=0.05; string_key=value; ;`
+	const def = `bool_key=false; int-key=0; float-key=1.0; string-key=; other-key=5;
 		duration-minutes=15m; duration-hours=12h; duration-days=30d;`
 
-	// bool-key and int-key should not be overwritten. Only other-key should be set.
-	sf.MergeAndCheckDefault(def)
+	_, err := NewSuperFlag("boolo-key=true").mergeAndCheckDefaultImpl(def)
+	require.Error(t, err)
+	_, err = newSuperFlagImpl("key-without-value")
+	require.Error(t, err)
 
-	require.Panics(t, func() {
-		// typo
-		NewSuperFlag("boolo-key=true").MergeAndCheckDefault(def)
-	})
+	// bool-key and int-key should not be overwritten. Only other-key should be set.
+	sf := NewSuperFlag(opt)
+	sf.MergeAndCheckDefault(def)
 
 	require.Equal(t, true, sf.GetBool("bool-key"))
 	require.Equal(t, uint64(5), sf.GetUint64("int-key"))


### PR DESCRIPTION
Currently, superflags panic with an index out of bounds if we pass a key without a value, eg. `"key1=value1; key2"`.

This PR fixes that. I've also added impl functions that throw errors to make the code more testable without throwing panics at the user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/259)
<!-- Reviewable:end -->
