### PR TITLE
cache: fix race when clearning a cache

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -348,6 +348,10 @@ loop:
 	for {
 		select {
 		case i := <-c.setBuf:
+			if i.wg != nil {
+				i.wg.Done()
+				continue
+			}
 			if i.flag != itemUpdate {
 				// In itemUpdate, the value is already set in the store.  So, no need to call
 				// onEvict here.

--- a/cache_test.go
+++ b/cache_test.go
@@ -715,7 +715,7 @@ func init() {
 	bucketDurationSecs = 1
 }
 
-func TestBlockOnShutdown(t *testing.T) {
+func TestBlockOnClear(t *testing.T) {
 	c, err := NewCache(&Config{
 		NumCounters: 100,
 		MaxCost:     10,
@@ -723,6 +723,7 @@ func TestBlockOnShutdown(t *testing.T) {
 		Metrics:     false,
 	})
 	require.NoError(t, err)
+	defer c.Close()
 
 	done := make(chan struct{})
 


### PR DESCRIPTION
Hiii!! Thanks for Ristretto, it's very nice! I've found an actual bug when wiring it up as a cache backend for Vitess; it can cause goroutines to block.

Fix and reproduction recipe attached!

```
When clearing a cache while other goroutines are actively `Wait`ing for
it, the waiting goroutines can become blocked indefinitely if one of the
cache items is flushed by the `Clear` code instead of by the background
worker, because the `Clear` code is not marking waitgroups as done.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/261)
<!-- Reviewable:end -->
