### PR TITLE
z/calloc: Enable riscv64 builds

### DIFF
--- a/z/calloc_64bit.go
+++ b/z/calloc_64bit.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-// +build amd64 arm64 arm64be ppc64 ppc64le mips64 mips64le s390x sparc64
+// +build amd64 arm64 arm64be ppc64 ppc64le mips64 mips64le riscv64 s390x sparc64
 
 package z
 


### PR DESCRIPTION
rv64 go port is available in latest go versions starting 1.14+

Signed-off-by: Khem Raj <raj.khem@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/262)
<!-- Reviewable:end -->
