### PR TITLE
Switch from log to glog

### DIFF
--- a/contrib/memtest/main.go
+++ b/contrib/memtest/main.go
@@ -20,7 +20,6 @@ package main
 import "C"
 import (
 	"fmt"
-	"log"
 	"math/rand"
 	"net/http"
 	_ "net/http/pprof"
@@ -34,6 +33,7 @@ import (
 
 	"github.com/dgraph-io/ristretto/z"
 	"github.com/dustin/go-humanize"
+	"github.com/golang/glog"
 )
 
 type S struct {
@@ -67,7 +67,7 @@ func newS(sz int) *S {
 	s.val = Calloc(sz)
 	copy(s.val, fill)
 	if s.next != nil {
-		log.Fatalf("news.next must be nil: %p", s.next)
+		glog.Fatalf("news.next must be nil: %p", s.next)
 	}
 	return s
 }
@@ -87,7 +87,7 @@ func (s *S) allocateNext(sz int) {
 
 func (s *S) deallocNext() {
 	if s.next == nil {
-		log.Fatal("next should not be nil")
+		glog.Fatal("next should not be nil")
 	}
 	next := s.next
 	s.next = next.next
@@ -161,13 +161,13 @@ func main() {
 	}()
 	go func() {
 		if err := http.ListenAndServe("0.0.0.0:8080", nil); err != nil {
-			log.Fatalf("Error: %v", err)
+			glog.Fatalf("Error: %v", err)
 		}
 	}()
 
 	viaLL()
 	if left := NumAllocBytes(); left != 0 {
-		log.Fatalf("Unable to deallocate all memory: %v\n", left)
+		glog.Fatalf("Unable to deallocate all memory: %v\n", left)
 	}
 	runtime.GC()
 	fmt.Println("Done. Reduced to zero memory usage.")

--- a/contrib/memtest/nojemalloc.go
+++ b/contrib/memtest/nojemalloc.go
@@ -5,7 +5,6 @@ package main
 // #include <stdlib.h>
 import "C"
 import (
-	"log"
 	"reflect"
 	"sync/atomic"
 	"unsafe"
@@ -41,5 +40,5 @@ func NumAllocBytes() int64 { return atomic.LoadInt64(&numbytes) }
 func check() {}
 
 func init() {
-	log.Printf("USING CALLOC")
+	glog.Printf("USING CALLOC")
 }

--- a/contrib/memtest/nojemalloc.go
+++ b/contrib/memtest/nojemalloc.go
@@ -8,6 +8,8 @@ import (
 	"reflect"
 	"sync/atomic"
 	"unsafe"
+
+	"github.com/golang/glog"
 )
 
 func Calloc(size int) []byte {
@@ -40,5 +42,5 @@ func NumAllocBytes() int64 { return atomic.LoadInt64(&numbytes) }
 func check() {}
 
 func init() {
-	glog.Printf("USING CALLOC")
+	glog.Infof("USING CALLOC")
 }

--- a/contrib/memtest/withjemalloc.go
+++ b/contrib/memtest/withjemalloc.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	"log"
+	"glog"
 
 	"github.com/dgraph-io/ristretto/z"
 )
@@ -14,7 +14,7 @@ func NumAllocBytes() int64   { return z.NumAllocBytes() }
 
 func check() {
 	if buf := z.CallocNoRef(1, "memtest"); len(buf) == 0 {
-		log.Fatalf("Not using manual memory management. Compile with jemalloc.")
+		glog.Fatalf("Not using manual memory management. Compile with jemalloc.")
 	} else {
 		z.Free(buf)
 	}
@@ -23,5 +23,5 @@ func check() {
 }
 
 func init() {
-	log.Printf("USING JEMALLOC")
+	glog.Printf("USING JEMALLOC")
 }

--- a/contrib/memtest/withjemalloc.go
+++ b/contrib/memtest/withjemalloc.go
@@ -3,9 +3,8 @@
 package main
 
 import (
-	"glog"
-
 	"github.com/dgraph-io/ristretto/z"
+	"github.com/google/glog"
 )
 
 func Calloc(size int) []byte { return z.Calloc(size, "memtest") }
@@ -23,5 +22,5 @@ func check() {
 }
 
 func init() {
-	glog.Printf("USING JEMALLOC")
+	glog.Infof("USING JEMALLOC")
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
 	github.com/dustin/go-humanize v1.0.0
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczC
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/z/bbloom.go
+++ b/z/bbloom.go
@@ -23,9 +23,10 @@ package z
 import (
 	"bytes"
 	"encoding/json"
-	"log"
 	"math"
 	"unsafe"
+
+	"github.com/golang/glog"
 )
 
 // helper
@@ -59,7 +60,7 @@ func NewBloomFilter(params ...float64) (bloomfilter *Bloom) {
 			entries, locs = uint64(params[0]), uint64(params[1])
 		}
 	} else {
-		log.Fatal("usage: New(float64(number_of_entries), float64(number_of_hashlocations))" +
+		glog.Fatal("usage: New(float64(number_of_entries), float64(number_of_hashlocations))" +
 			" i.e. New(float64(1000), float64(3)) or New(float64(number_of_entries)," +
 			" float64(number_of_hashlocations)) i.e. New(float64(1000), float64(0.03))")
 	}
@@ -204,7 +205,7 @@ func (bl Bloom) JSONMarshal() []byte {
 	}
 	data, err := json.Marshal(bloomImEx)
 	if err != nil {
-		log.Fatal("json.Marshal failed: ", err)
+		glog.Fatal("json.Marshal failed: ", err)
 	}
 	return data
 }

--- a/z/buffer.go
+++ b/z/buffer.go
@@ -20,12 +20,12 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"math"
 	"os"
 	"sort"
 	"sync/atomic"
 
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
 )
 
@@ -76,7 +76,7 @@ const smallBufferSize = 64
 func NewBuffer(sz int, tag string) *Buffer {
 	buf, err := NewBufferWithDir(sz, MaxBufferSize, UseCalloc, "", tag)
 	if err != nil {
-		log.Fatalf("while creating buffer: %v", err)
+		glog.Fatalf("while creating buffer: %v", err)
 	}
 	return buf
 }
@@ -154,7 +154,7 @@ func NewBufferWithDir(sz, maxSz int, bufType BufferType, dir, tag string) (*Buff
 			return nil, err
 		}
 	default:
-		log.Fatalf("Invalid bufType: %q\n", bufType)
+		glog.Fatalf("Invalid bufType: %q\n", bufType)
 	}
 
 	b.buf[0] = 0x00
@@ -228,7 +228,7 @@ func (b *Buffer) Grow(n int) {
 		}
 	case UseMmap:
 		if err := b.fd.Truncate(int64(b.curSz)); err != nil {
-			log.Fatalf("While trying to truncate file %s to size: %d error: %v\n",
+			glog.Fatalf("While trying to truncate file %s to size: %d error: %v\n",
 				b.fd.Name(), b.curSz, err)
 		}
 	default:
@@ -326,12 +326,12 @@ func (s *sortHelper) sortSmall(start, end int) {
 
 func assert(b bool) {
 	if !b {
-		log.Fatalf("%+v", errors.Errorf("Assertion failure"))
+		glog.Fatalf("%+v", errors.Errorf("Assertion failure"))
 	}
 }
 func check(err error) {
 	if err != nil {
-		log.Fatalf("%+v", err)
+		glog.Fatalf("%+v", err)
 	}
 }
 func check2(_ interface{}, err error) {

--- a/z/flags.go
+++ b/z/flags.go
@@ -2,7 +2,6 @@ package z
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -11,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
 )
 
@@ -109,7 +109,7 @@ type SuperFlag struct {
 func NewSuperFlag(flag string) *SuperFlag {
 	sf, err := newSuperFlagImpl(flag)
 	if err != nil {
-		log.Fatal(err)
+		glog.Fatal(err)
 	}
 	return sf
 }
@@ -136,7 +136,7 @@ func (sf *SuperFlag) String() string {
 func (sf *SuperFlag) MergeAndCheckDefault(flag string) *SuperFlag {
 	sf, err := sf.mergeAndCheckDefaultImpl(flag)
 	if err != nil {
-		log.Fatal(err)
+		glog.Fatal(err)
 	}
 	return sf
 }
@@ -207,7 +207,7 @@ func (sf *SuperFlag) GetBool(opt string) bool {
 		err = errors.Wrapf(err,
 			"Unable to parse %s as bool for key: %s. Options: %s\n",
 			val, opt, sf)
-		log.Fatalf("%+v", err)
+		glog.Fatalf("%+v", err)
 	}
 	return b
 }
@@ -222,7 +222,7 @@ func (sf *SuperFlag) GetFloat64(opt string) float64 {
 		err = errors.Wrapf(err,
 			"Unable to parse %s as float64 for key: %s. Options: %s\n",
 			val, opt, sf)
-		log.Fatalf("%+v", err)
+		glog.Fatalf("%+v", err)
 	}
 	return f
 }
@@ -237,7 +237,7 @@ func (sf *SuperFlag) GetInt64(opt string) int64 {
 		err = errors.Wrapf(err,
 			"Unable to parse %s as int64 for key: %s. Options: %s\n",
 			val, opt, sf)
-		log.Fatalf("%+v", err)
+		glog.Fatalf("%+v", err)
 	}
 	return i
 }
@@ -252,7 +252,7 @@ func (sf *SuperFlag) GetUint64(opt string) uint64 {
 		err = errors.Wrapf(err,
 			"Unable to parse %s as uint64 for key: %s. Options: %s\n",
 			val, opt, sf)
-		log.Fatalf("%+v", err)
+		glog.Fatalf("%+v", err)
 	}
 	return u
 }
@@ -267,7 +267,7 @@ func (sf *SuperFlag) GetUint32(opt string) uint32 {
 		err = errors.Wrapf(err,
 			"Unable to parse %s as uint32 for key: %s. Options: %s\n",
 			val, opt, sf)
-		log.Fatalf("%+v", err)
+		glog.Fatalf("%+v", err)
 	}
 	return uint32(u)
 }
@@ -283,7 +283,7 @@ func (sf *SuperFlag) GetPath(opt string) string {
 	p := sf.GetString(opt)
 	path, err := expandPath(p)
 	if err != nil {
-		log.Fatalf("Failed to get path: %+v", err)
+		glog.Fatalf("Failed to get path: %+v", err)
 	}
 	return path
 }


### PR DESCRIPTION
Since we use `glog` within Dgraph, switching Ristretto to use `glog` as well would provide uniformity in logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/263)
<!-- Reviewable:end -->
