### PR TITLE
Use z.Buffer backing for B+ tree

### DIFF
--- a/z/btree.go
+++ b/z/btree.go
@@ -53,8 +53,12 @@ func (t *Tree) initRootNode() {
 }
 
 // NewTree returns an in-memory B+ tree.
-func NewTree() *Tree {
-	t := &Tree{buffer: NewBuffer(minSize, "tree")}
+func NewTree(tag string) *Tree {
+	const defaultTag = "tree"
+	if tag == "" {
+		tag = defaultTag
+	}
+	t := &Tree{buffer: NewBuffer(minSize, tag)}
 	t.Reset()
 	return t
 }
@@ -75,6 +79,7 @@ func NewTreePersistent(path string) (*Tree, error) {
 func (t *Tree) Reset() {
 	t.nextPage = 1
 	t.freePage = 0
+	Memclr(t.data)
 	t.buffer.Reset()
 	t.buffer.AllocateOffset(minSize)
 	t.data = t.buffer.Bytes()
@@ -84,7 +89,7 @@ func (t *Tree) Reset() {
 
 // Close releases the memory used by the tree.
 func (t *Tree) Close() error {
-	if t != nil {
+	if t == nil {
 		return nil
 	}
 	return t.buffer.Release()

--- a/z/btree.go
+++ b/z/btree.go
@@ -65,11 +65,10 @@ func NewTree(tag string) *Tree {
 
 // NewTree returns a persistent on-disk B+ tree.
 func NewTreePersistent(path string) (*Tree, error) {
-	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0666)
+	buffer, err := NewBufferPersistent(path)
 	if err != nil {
 		return nil, err
 	}
-	buffer := NewBufferFromFile(file, 0).WithPersistent(true)
 	tree := &Tree{buffer: buffer}
 	tree.Reset()
 	return tree, nil

--- a/z/btree.go
+++ b/z/btree.go
@@ -38,6 +38,7 @@ var (
 // Tree represents the structure for custom mmaped B+ tree.
 // It supports keys in range [1, math.MaxUint64-1] and values [1, math.Uint64].
 type Tree struct {
+	buffer   *Buffer
 	data     []byte
 	nextPage uint64
 	freePage uint64
@@ -51,9 +52,9 @@ func (t *Tree) initRootNode() {
 	t.Set(absoluteMax, 0)
 }
 
-// NewTree returns a memory mapped B+ tree with given filename.
+// NewTree returns an in-memory B+ tree.
 func NewTree() *Tree {
-	t := &Tree{}
+	t := &Tree{buffer: NewBuffer(minSize, "tree")}
 	t.Reset()
 	return t
 }
@@ -62,7 +63,9 @@ func NewTree() *Tree {
 func (t *Tree) Reset() {
 	t.nextPage = 1
 	t.freePage = 0
-	t.data = make([]byte, minSize)
+	t.buffer.Reset()
+	t.buffer.AllocateOffset(minSize)
+	t.data = t.buffer.Bytes()
 	t.stats = TreeStats{}
 	t.initRootNode()
 }
@@ -82,7 +85,7 @@ func (t *Tree) Stats() TreeStats {
 	numPages := int(t.nextPage - 1)
 	out := TreeStats{
 		Bytes:        numPages * pageSize,
-		Allocated:    cap(t.data),
+		Allocated:    len(t.data),
 		NumLeafKeys:  t.stats.NumLeafKeys,
 		NumPages:     numPages,
 		NumPagesFree: t.stats.NumPagesFree,
@@ -114,16 +117,10 @@ func (t *Tree) newNode(bit uint64) node {
 		pageId = t.nextPage
 		t.nextPage++
 		offset := int(pageId) * pageSize
-		// Double the size with an upper cap of 1GB, if current buffer is insufficient.
-		if offset+pageSize > len(t.data) {
-			const oneGB = 1 << 30
-			newSz := 2 * len(t.data)
-			if newSz > len(t.data)+oneGB {
-				newSz = len(t.data) + oneGB
-			}
-			out := make([]byte, newSz)
-			copy(out, t.data)
-			t.data = out
+		reqSize := offset + pageSize
+		if reqSize > len(t.data) {
+			t.buffer.AllocateOffset(reqSize - len(t.data))
+			t.data = t.buffer.Bytes()
 		}
 	}
 	n := t.node(pageId)

--- a/z/btree.go
+++ b/z/btree.go
@@ -78,7 +78,7 @@ func NewTreePersistent(path string) (*Tree, error) {
 func (t *Tree) Reset() {
 	t.nextPage = 1
 	t.freePage = 0
-	Memclr(t.data)
+	Memclr(t.buffer.buf)
 	t.buffer.Reset()
 	t.buffer.AllocateOffset(minSize)
 	t.data = t.buffer.Bytes()

--- a/z/btree_test.go
+++ b/z/btree_test.go
@@ -40,6 +40,7 @@ func setPageSize(sz int) {
 
 func TestTree(t *testing.T) {
 	bt := NewTree()
+	defer func() { require.NoError(t, bt.Close()) }()
 
 	N := uint64(256 * 256)
 	for i := uint64(1); i < N; i++ {
@@ -61,6 +62,7 @@ func TestTree(t *testing.T) {
 func TestTreeBasic(t *testing.T) {
 	setAndGet := func() {
 		bt := NewTree()
+		defer func() { require.NoError(t, bt.Close()) }()
 
 		N := uint64(1 << 20)
 		mp := make(map[uint64]uint64)
@@ -84,6 +86,8 @@ func TestTreeBasic(t *testing.T) {
 
 func TestTreeReset(t *testing.T) {
 	bt := NewTree()
+	defer func() { require.NoError(t, bt.Close()) }()
+
 	N := 1 << 10
 	val := rand.Uint64()
 	for i := 0; i < N; i++ {
@@ -136,6 +140,7 @@ func TestTreeCycle(t *testing.T) {
 
 func TestTreeIterateKV(t *testing.T) {
 	bt := NewTree()
+	defer func() { require.NoError(t, bt.Close()) }()
 
 	// Set entries: (i, i*10)
 	const n = uint64(1 << 20)
@@ -170,6 +175,7 @@ func TestOccupancyRatio(t *testing.T) {
 	require.Equal(t, 4, maxKeys)
 
 	bt := NewTree()
+	defer func() { require.NoError(t, bt.Close()) }()
 
 	expectedRatio := float64(1) * 100 / float64(2*maxKeys) // 2 because we'll have 2 pages.
 	stats := bt.Stats()
@@ -277,6 +283,7 @@ func BenchmarkPurge(b *testing.B) {
 	b.Run("btree", func(b *testing.B) {
 		start := time.Now()
 		bt := NewTree()
+		defer func() { require.NoError(b, bt.Close()) }()
 		for i := 0; i < N; i++ {
 			bt.Set(rand.Uint64(), uint64(i))
 		}
@@ -300,6 +307,7 @@ func BenchmarkWrite(b *testing.B) {
 	})
 	b.Run("btree", func(b *testing.B) {
 		bt := NewTree()
+		defer func() { require.NoError(b, bt.Close()) }()
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
 			k := rand.Uint64()
@@ -333,6 +341,7 @@ func BenchmarkRead(b *testing.B) {
 	})
 
 	bt := NewTree()
+	defer func() { require.NoError(b, bt.Close()) }()
 	for i := 0; i < N; i++ {
 		k := uint64(rand.Intn(2*N)) + 1
 		bt.Set(k, k)

--- a/z/btree_test.go
+++ b/z/btree_test.go
@@ -39,7 +39,7 @@ func setPageSize(sz int) {
 }
 
 func TestTree(t *testing.T) {
-	bt := NewTree()
+	bt := NewTree("TestTree")
 	defer func() { require.NoError(t, bt.Close()) }()
 
 	N := uint64(256 * 256)
@@ -61,7 +61,7 @@ func TestTree(t *testing.T) {
 
 func TestTreeBasic(t *testing.T) {
 	setAndGet := func() {
-		bt := NewTree()
+		bt := NewTree("TestTreeBasic")
 		defer func() { require.NoError(t, bt.Close()) }()
 
 		N := uint64(1 << 20)
@@ -85,7 +85,7 @@ func TestTreeBasic(t *testing.T) {
 }
 
 func TestTreeReset(t *testing.T) {
-	bt := NewTree()
+	bt := NewTree("TestTreeReset")
 	defer func() { require.NoError(t, bt.Close()) }()
 
 	N := 1 << 10
@@ -118,7 +118,9 @@ func TestTreeReset(t *testing.T) {
 }
 
 func TestTreeCycle(t *testing.T) {
-	bt := NewTree()
+	bt := NewTree("TestTreeCycle")
+	defer func() { require.NoError(t, bt.Close()) }()
+
 	val := uint64(0)
 	for i := 0; i < 16; i++ {
 		for j := 0; j < 1e6+i*1e4; j++ {
@@ -139,7 +141,7 @@ func TestTreeCycle(t *testing.T) {
 }
 
 func TestTreeIterateKV(t *testing.T) {
-	bt := NewTree()
+	bt := NewTree("TestTreeIterateKV")
 	defer func() { require.NoError(t, bt.Close()) }()
 
 	// Set entries: (i, i*10)
@@ -174,7 +176,7 @@ func TestOccupancyRatio(t *testing.T) {
 	defer setPageSize(os.Getpagesize())
 	require.Equal(t, 4, maxKeys)
 
-	bt := NewTree()
+	bt := NewTree("TestOccupancyRatio")
 	defer func() { require.NoError(t, bt.Close()) }()
 
 	expectedRatio := float64(1) * 100 / float64(2*maxKeys) // 2 because we'll have 2 pages.
@@ -282,7 +284,7 @@ func BenchmarkPurge(b *testing.B) {
 
 	b.Run("btree", func(b *testing.B) {
 		start := time.Now()
-		bt := NewTree()
+		bt := NewTree("BenchmarkPurge")
 		defer func() { require.NoError(b, bt.Close()) }()
 		for i := 0; i < N; i++ {
 			bt.Set(rand.Uint64(), uint64(i))
@@ -306,7 +308,7 @@ func BenchmarkWrite(b *testing.B) {
 		}
 	})
 	b.Run("btree", func(b *testing.B) {
-		bt := NewTree()
+		bt := NewTree("BenchmarkWrite")
 		defer func() { require.NoError(b, bt.Close()) }()
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
@@ -340,7 +342,7 @@ func BenchmarkRead(b *testing.B) {
 		}
 	})
 
-	bt := NewTree()
+	bt := NewTree("BenchmarkRead")
 	defer func() { require.NoError(b, bt.Close()) }()
 	for i := 0; i < N; i++ {
 		k := uint64(rand.Intn(2*N)) + 1

--- a/z/buffer.go
+++ b/z/buffer.go
@@ -46,7 +46,7 @@ type Buffer struct {
 	maxSz         int        // causes a panic if the buffer grows beyond this size
 	mmapFile      *MmapFile  // optional mmap backing for the buffer
 	autoMmapAfter int        // Calloc falls back to an mmaped tmpfile after crossing this size
-	autoMmapDir   string     // must be set if using autoMmapAfter
+	autoMmapDir   string     // directory for autoMmap to create a tempfile in
 	persistent    bool       // when enabled, Release will not delete the underlying mmap file
 	tag           string     // used for jemalloc stats
 }
@@ -496,6 +496,9 @@ func (b *Buffer) Reset() {
 // Release would free up the memory allocated by the buffer. Once the usage of buffer is done, it is
 // important to call Release, otherwise a memory leak can happen.
 func (b *Buffer) Release() error {
+	if b == nil {
+		return nil
+	}
 	switch b.bufType {
 	case UseCalloc:
 		Free(b.buf)

--- a/z/buffer.go
+++ b/z/buffer.go
@@ -28,6 +28,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const defaultCapacity = 64
+
 // Buffer is equivalent of bytes.Buffer without the ability to read. It is NOT thread-safe.
 //
 // In UseCalloc mode, z.Calloc is used to allocate memory, which depending upon how the code is
@@ -51,12 +53,9 @@ type Buffer struct {
 	tag           string     // used for jemalloc stats
 }
 
-const (
-	defaultCapacity = 64
-	defaultTag      = "buffer"
-)
-
 func NewBuffer(capacity int, tag string) *Buffer {
+	const defaultTag = "buffer"
+
 	if capacity == 0 {
 		capacity = defaultCapacity
 	}
@@ -69,7 +68,7 @@ func NewBuffer(capacity int, tag string) *Buffer {
 		curSz:   capacity,
 		offset:  8,
 		padding: 8,
-		tag:     defaultTag,
+		tag:     tag,
 	}
 }
 
@@ -151,7 +150,7 @@ func (b *Buffer) Grow(n int) {
 	if b.buf == nil {
 		panic("z.Buffer needs to be initialized before using")
 	}
-	if b.maxSz != 0 && int(b.offset)+n > b.maxSz {
+	if b.maxSz > 0 && int(b.offset)+n > b.maxSz {
 		err := fmt.Errorf(
 			"z.Buffer max size exceeded: %d offset: %d grow: %d", b.maxSz, b.offset, n)
 		panic(err)

--- a/z/buffer.go
+++ b/z/buffer.go
@@ -406,7 +406,7 @@ func (b *Buffer) SortSliceBetween(start, end int, less LessFunc) {
 		return
 	}
 	if start == 0 {
-		panic("start can never be zero") // TODO(ajeet): why?
+		panic("start can never be zero")
 	}
 
 	var offsets []int

--- a/z/buffer_test.go
+++ b/z/buffer_test.go
@@ -108,35 +108,34 @@ func TestBufferWrite(t *testing.T) {
 	}
 }
 
-// TODO(ajeet)
-// func TestBufferAutoMmap(t *testing.T) {
-// 	buf := NewBuffer(1<<20, "test").WithAutoMmap(64 << 20)
-// 	defer buf.Release()
+func TestBufferAutoMmap(t *testing.T) {
+	buf := NewBuffer(1<<20, "test").WithAutoMmap(64<<20, "")
+	defer buf.Release()
 
-// 	N := 128 << 10
-// 	var wb [1024]byte
-// 	for i := 0; i < N; i++ {
-// 		rand.Read(wb[:])
-// 		b := buf.SliceAllocate(len(wb))
-// 		copy(b, wb[:])
-// 	}
-// 	t.Logf("Buffer size: %d\n", buf.LenWithPadding())
+	N := 128 << 10
+	var wb [1024]byte
+	for i := 0; i < N; i++ {
+		rand.Read(wb[:])
+		b := buf.SliceAllocate(len(wb))
+		copy(b, wb[:])
+	}
+	t.Logf("Buffer size: %d\n", buf.LenWithPadding())
 
-// 	buf.SortSlice(func(l, r []byte) bool {
-// 		return bytes.Compare(l, r) < 0
-// 	})
-// 	t.Logf("sort done\n")
+	buf.SortSlice(func(l, r []byte) bool {
+		return bytes.Compare(l, r) < 0
+	})
+	t.Logf("sort done\n")
 
-// 	var count int
-// 	var last []byte
-// 	buf.SliceIterate(func(slice []byte) error {
-// 		require.True(t, bytes.Compare(slice, last) >= 0)
-// 		last = append(last[:0], slice...)
-// 		count++
-// 		return nil
-// 	})
-// 	require.Equal(t, N, count)
-// }
+	var count int
+	var last []byte
+	buf.SliceIterate(func(slice []byte) error {
+		require.True(t, bytes.Compare(slice, last) >= 0)
+		last = append(last[:0], slice...)
+		count++
+		return nil
+	})
+	require.Equal(t, N, count)
+}
 
 func TestBufferSimpleSort(t *testing.T) {
 	buf := NewBuffer(1<<20, "test")
@@ -171,8 +170,8 @@ func TestBufferSlice(t *testing.T) {
 
 	const capacity = 32
 	buffers := []*Buffer{
-		NewBuffer(capacity, "test").WithPadding(8),
-		NewBufferFromFile(file, capacity).WithPadding(8),
+		NewBuffer(capacity, "test"),
+		NewBufferFromFile(file, capacity),
 	}
 
 	for _, buffer := range buffers {

--- a/z/buffer_test.go
+++ b/z/buffer_test.go
@@ -33,7 +33,7 @@ import (
 func TestBuffer(t *testing.T) {
 	rand.Seed(time.Now().Unix())
 
-	file, err := ioutil.TempFile("", "buffer")
+	file, err := ioutil.TempFile("", "TestBuffer")
 	require.NoError(t, err)
 
 	const capacity = 512
@@ -73,7 +73,7 @@ func TestBuffer(t *testing.T) {
 func TestBufferWrite(t *testing.T) {
 	rand.Seed(time.Now().Unix())
 
-	file, err := ioutil.TempFile("", "buffer")
+	file, err := ioutil.TempFile("", "TestBufferWrite")
 	require.NoError(t, err)
 
 	const capacity = 32
@@ -165,7 +165,7 @@ func TestBufferSimpleSort(t *testing.T) {
 }
 
 func TestBufferSlice(t *testing.T) {
-	file, err := ioutil.TempFile("", "buffer")
+	file, err := ioutil.TempFile("", "TestBufferSlice")
 	require.NoError(t, err)
 
 	const capacity = 32
@@ -226,7 +226,7 @@ func TestBufferSlice(t *testing.T) {
 }
 
 func TestBufferSort(t *testing.T) {
-	file, err := ioutil.TempFile("", "buffer")
+	file, err := ioutil.TempFile("", "TestBufferSort")
 	require.NoError(t, err)
 
 	const capacity = 32

--- a/z/buffer_test.go
+++ b/z/buffer_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"sort"
 	"testing"
@@ -32,15 +31,8 @@ import (
 
 func TestBuffer(t *testing.T) {
 	rand.Seed(time.Now().Unix())
-
-	file, err := ioutil.TempFile("", "TestBuffer")
-	require.NoError(t, err)
-
 	const capacity = 512
-	buffers := []*Buffer{
-		NewBuffer(capacity, "test"),
-		NewBufferFromFile(file, capacity),
-	}
+	buffers := newBuffers(t, capacity)
 
 	for _, buf := range buffers {
 		name := fmt.Sprintf("Using buffer type: %s", buf.bufType)
@@ -57,7 +49,7 @@ func TestBuffer(t *testing.T) {
 			var bigData [1024]byte
 			rand.Read(bigData[:])
 
-			_, err = buf.Write(smallData[:])
+			_, err := buf.Write(smallData[:])
 			require.NoError(t, err, "unable to write data to page buffer")
 			_, err = buf.Write(bigData[:])
 			require.NoError(t, err, "unable to write data to page buffer")
@@ -72,15 +64,8 @@ func TestBuffer(t *testing.T) {
 
 func TestBufferWrite(t *testing.T) {
 	rand.Seed(time.Now().Unix())
-
-	file, err := ioutil.TempFile("", "TestBufferWrite")
-	require.NoError(t, err)
-
 	const capacity = 32
-	buffers := []*Buffer{
-		NewBuffer(capacity, "test"),
-		NewBufferFromFile(file, capacity),
-	}
+	buffers := newBuffers(t, capacity)
 
 	for _, buf := range buffers {
 		name := fmt.Sprintf("Using buffer type: %s", buf.bufType)
@@ -165,14 +150,8 @@ func TestBufferSimpleSort(t *testing.T) {
 }
 
 func TestBufferSlice(t *testing.T) {
-	file, err := ioutil.TempFile("", "TestBufferSlice")
-	require.NoError(t, err)
-
 	const capacity = 32
-	buffers := []*Buffer{
-		NewBuffer(capacity, "test"),
-		NewBufferFromFile(file, capacity),
-	}
+	buffers := newBuffers(t, capacity)
 
 	for _, buf := range buffers {
 		name := fmt.Sprintf("Using buffer type: %s", buf.bufType)
@@ -226,14 +205,8 @@ func TestBufferSlice(t *testing.T) {
 }
 
 func TestBufferSort(t *testing.T) {
-	file, err := ioutil.TempFile("", "TestBufferSort")
-	require.NoError(t, err)
-
 	const capacity = 32
-	buffers := []*Buffer{
-		NewBuffer(capacity, "test"),
-		NewBufferFromFile(file, capacity),
-	}
+	buffers := newBuffers(t, capacity)
 
 	for _, buf := range buffers {
 		name := fmt.Sprintf("Using buffer type: %s", buf.bufType)
@@ -291,4 +264,17 @@ func TestBufferPadding(t *testing.T) {
 	copy(buf.Bytes(), b)
 	data := buf.Data(buf.StartOffset())
 	require.Equal(t, b, data[:sz])
+}
+
+func newBuffers(t *testing.T, capacity int) []*Buffer {
+	var bufs []*Buffer
+
+	buf := NewBuffer(capacity, "test")
+	bufs = append(bufs, buf)
+
+	buf, err := NewBufferTmp("", capacity)
+	require.NoError(t, err)
+	bufs = append(bufs, buf)
+
+	return bufs
 }

--- a/z/buffer_test.go
+++ b/z/buffer_test.go
@@ -33,7 +33,7 @@ import (
 func TestBuffer(t *testing.T) {
 	rand.Seed(time.Now().Unix())
 
-	file, err := ioutil.TempFile("", "")
+	file, err := ioutil.TempFile("", "buffer")
 	require.NoError(t, err)
 
 	const capacity = 512
@@ -43,10 +43,10 @@ func TestBuffer(t *testing.T) {
 	}
 
 	for _, buf := range buffers {
-		defer func() { require.NoError(t, buf.Release()) }()
-
 		name := fmt.Sprintf("Using buffer type: %s", buf.bufType)
 		t.Run(name, func(t *testing.T) {
+			defer func() { require.NoError(t, buf.Release()) }()
+
 			// This is just for verifying result
 			var bytesBuf bytes.Buffer
 			bytesBuf.Grow(capacity)
@@ -66,9 +66,6 @@ func TestBuffer(t *testing.T) {
 			bytesBuf.Write(smallData[:])
 			bytesBuf.Write(bigData[:])
 			require.Equal(t, buf.Bytes(), bytesBuf.Bytes())
-
-			err := buf.Release()
-			require.NoError(t, err)
 		})
 	}
 }
@@ -76,7 +73,7 @@ func TestBuffer(t *testing.T) {
 func TestBufferWrite(t *testing.T) {
 	rand.Seed(time.Now().Unix())
 
-	file, err := ioutil.TempFile("", "")
+	file, err := ioutil.TempFile("", "buffer")
 	require.NoError(t, err)
 
 	const capacity = 32
@@ -86,10 +83,10 @@ func TestBufferWrite(t *testing.T) {
 	}
 
 	for _, buf := range buffers {
-		defer func() { require.NoError(t, buf.Release()) }()
-
 		name := fmt.Sprintf("Using buffer type: %s", buf.bufType)
 		t.Run(name, func(t *testing.T) {
+			defer func() { require.NoError(t, buf.Release()) }()
+
 			var data [128]byte
 			rand.Read(data[:])
 			bytesBuf := new(bytes.Buffer)
@@ -168,7 +165,7 @@ func TestBufferSimpleSort(t *testing.T) {
 }
 
 func TestBufferSlice(t *testing.T) {
-	file, err := ioutil.TempFile("", "")
+	file, err := ioutil.TempFile("", "buffer")
 	require.NoError(t, err)
 
 	const capacity = 32
@@ -178,10 +175,9 @@ func TestBufferSlice(t *testing.T) {
 	}
 
 	for _, buf := range buffers {
-		defer func() { require.NoError(t, buf.Release()) }()
-
 		name := fmt.Sprintf("Using buffer type: %s", buf.bufType)
 		t.Run(name, func(t *testing.T) {
+			defer func() { require.NoError(t, buf.Release()) }()
 			count := 10000
 			exp := make([][]byte, 0, count)
 
@@ -225,15 +221,12 @@ func TestBufferSlice(t *testing.T) {
 			})
 			t.Logf("Done sorting\n")
 			compare() // same order after sort.
-
-			err := buf.Release()
-			require.NoError(t, err)
 		})
 	}
 }
 
 func TestBufferSort(t *testing.T) {
-	file, err := ioutil.TempFile("", "")
+	file, err := ioutil.TempFile("", "buffer")
 	require.NoError(t, err)
 
 	const capacity = 32
@@ -243,11 +236,11 @@ func TestBufferSort(t *testing.T) {
 	}
 
 	for _, buf := range buffers {
-		defer func() { require.NoError(t, buf.Release()) }()
-
 		name := fmt.Sprintf("Using buffer type: %s", buf.bufType)
 		t.Run(name, func(t *testing.T) {
+			defer func() { require.NoError(t, buf.Release()) }()
 			const N = 10000
+
 			for i := 0; i < N; i++ {
 				newSlice := buf.SliceAllocate(8)
 				uid := uint64(rand.Int63())
@@ -279,9 +272,6 @@ func TestBufferSort(t *testing.T) {
 				test(i-10, i)
 			}
 			test(0, N)
-
-			err := buf.Release()
-			require.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
- `z.Tree` should use a `z.Buffer` backing.
- `z.Buffer` should use a `z.MmapFile` backing.
- Add persistent API to `z.Buffer`, so it doesn't delete the file after closing.
- Add persistent API to `z.Tree`, so that we can use it for persistent storage.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/268)
<!-- Reviewable:end -->
