### PR TITLE
Initialize persistent tree correctly

### DIFF
--- a/z/btree.go
+++ b/z/btree.go
@@ -79,7 +79,7 @@ func NewTreePersistent(path string) (*Tree, error) {
 	t.buffer.offset = uint64(len(t.buffer.buf))
 	t.data = t.buffer.Bytes()
 
-	// pageID can never be 0 is the tree has been initialized.
+	// pageID can never be 0 if the tree has been initialized.
 	root := t.node(1)
 	isInitialized := root.pageID() != 0
 

--- a/z/btree.go
+++ b/z/btree.go
@@ -79,17 +79,14 @@ func NewTreePersistent(path string) (*Tree, error) {
 	t.buffer.offset = uint64(len(t.buffer.buf))
 	t.data = t.buffer.Bytes()
 
-	// TODO(ajeet): can we do better than this?
-	isInitialized := false
-	for _, b := range t.data {
-		if b != 0 {
-			isInitialized = true
-			break
-		}
-	}
+	// pageID can never be 0 is the tree has been initialized.
+	root := t.node(1)
+	isInitialized := root.pageID() != 0
+
 	if !isInitialized {
 		t.nextPage = 1
 		t.freePage = 0
+		t.initRootNode()
 		return t, nil
 	}
 

--- a/z/btree.go
+++ b/z/btree.go
@@ -99,13 +99,17 @@ func NewTreePersistent(path string) (*Tree, error) {
 		if pageId := n.pageID(); pageId > t.nextPage {
 			t.nextPage = pageId
 		}
+		// If this is a leaf node, increment the stats.
+		if n.isLeaf() {
+			t.stats.NumLeafKeys++
+		}
 	})
 
 	// Calculate t.freePage by finding the page to which no other page points.
 	// usedPages[i] is true if pageId i+1 is in use.
 	usedPages := make([]bool, t.nextPage)
-	// If a node points to a page, mark it as used.
 	t.Iterate(func(n node) {
+		// If a node points to a page, mark it as used.
 		i := n.pageID() - 1
 		usedPages[i] = true
 	})
@@ -115,6 +119,7 @@ func NewTreePersistent(path string) (*Tree, error) {
 		if !used {
 			pageId := uint64(i) + 1
 			pointedPages = append(pointedPages, t.node(pageId).uint64(0))
+			t.stats.NumPagesFree++
 		}
 	}
 	// Mark all pages being pointed to as used.

--- a/z/btree.go
+++ b/z/btree.go
@@ -79,6 +79,20 @@ func NewTreePersistent(path string) (*Tree, error) {
 	t.buffer.offset = uint64(len(t.buffer.buf))
 	t.data = t.buffer.Bytes()
 
+	// TODO(ajeet): can we do better than this?
+	isInitialized := false
+	for _, b := range t.data {
+		if b != 0 {
+			isInitialized = true
+			break
+		}
+	}
+	if !isInitialized {
+		t.nextPage = 1
+		t.freePage = 0
+		return t, nil
+	}
+
 	// Calculate t.nextPage by finding the highest pageId among all the nodes.
 	t.nextPage = 0
 	t.Iterate(func(n node) {

--- a/z/btree.go
+++ b/z/btree.go
@@ -91,20 +91,21 @@ func NewTreePersistent(path string) (*Tree, error) {
 	}
 
 	// Calculate t.nextPage by finding the highest pageId among all the nodes.
-	t.nextPage = 0
+	maxPageId := uint64(0)
 	t.Iterate(func(n node) {
 		if pageId := n.pageID(); pageId > t.nextPage {
-			t.nextPage = pageId
+			maxPageId = pageId
 		}
 		// If this is a leaf node, increment the stats.
 		if n.isLeaf() {
-			t.stats.NumLeafKeys++
+			t.stats.NumLeafKeys += n.numKeys()
 		}
 	})
+	t.nextPage = maxPageId + 1
 
 	// Calculate t.freePage by finding the page to which no other page points.
 	// usedPages[i] is true if pageId i+1 is in use.
-	usedPages := make([]bool, t.nextPage)
+	usedPages := make([]bool, maxPageId)
 	t.Iterate(func(n node) {
 		// If a node points to a page, mark it as used.
 		i := n.pageID() - 1

--- a/z/btree_test.go
+++ b/z/btree_test.go
@@ -64,7 +64,6 @@ func TestTreePersistent(t *testing.T) {
 	dir, err := ioutil.TempDir("", "")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
-
 	path := filepath.Join(dir, "tree.buf")
 
 	// Create a tree and validate the data.
@@ -78,10 +77,20 @@ func TestTreePersistent(t *testing.T) {
 		require.Equal(t, i*2, bt.Get(i))
 	}
 	require.NoError(t, bt.Close())
+	freePage := bt.freePage
+	nextPage := bt.nextPage
+	stats := bt.Stats()
 
 	// Reopen tree and validate the data.
 	bt, err = NewTreePersistent(path)
 	require.NoError(t, err)
+	require.Equal(t, freePage, bt.freePage)
+	require.Equal(t, nextPage, bt.nextPage)
+	statsNew := bt.Stats()
+	// When reopening a tree, the allocated size becomes the file size.
+	// We don't need to compare this, it doesn't change anything in the tree.
+	statsNew.Allocated = stats.Allocated
+	require.Equal(t, stats, statsNew)
 	for i := uint64(1); i < N; i++ {
 		require.Equal(t, i*2, bt.Get(i))
 	}

--- a/z/btree_test.go
+++ b/z/btree_test.go
@@ -69,7 +69,7 @@ func TestTreePersistent(t *testing.T) {
 	// Create a tree and validate the data.
 	bt, err := NewTreePersistent(path)
 	require.NoError(t, err)
-	N := uint64(256 * 256)
+	N := uint64(64 << 10)
 	for i := uint64(1); i < N; i++ {
 		bt.Set(i, i*2)
 	}

--- a/z/btree_test.go
+++ b/z/btree_test.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 	"time"
@@ -57,6 +58,35 @@ func TestTree(t *testing.T) {
 	for i := uint64(100); i < N; i++ {
 		require.Equal(t, i, bt.Get(i))
 	}
+}
+
+func TestTreePersistent(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "tree.buf")
+
+	// Create a tree and validate the data.
+	bt, err := NewTreePersistent(path)
+	require.NoError(t, err)
+	N := uint64(256 * 256)
+	for i := uint64(1); i < N; i++ {
+		bt.Set(i, i*2)
+	}
+	for i := uint64(1); i < N; i++ {
+		require.Equal(t, i*2, bt.Get(i))
+	}
+	require.NoError(t, bt.Close())
+
+	// Reopen tree and validate the data.
+	bt, err = NewTreePersistent(path)
+	require.NoError(t, err)
+	for i := uint64(1); i < N; i++ {
+		require.Equal(t, i*2, bt.Get(i))
+	}
+	require.NoError(t, err)
+	require.NoError(t, bt.Close())
 }
 
 func TestTreeBasic(t *testing.T) {


### PR DESCRIPTION
`PersistentTree` currently does not set `t.freePage` and `t.nextPage` correctly upon opening an existing file, leading to errors. Additionally, stats are also lost. This PR computes these values when the tree is initialized.

TODO:
- [x] Add tests for `PersistentTree`

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/271)
<!-- Reviewable:end -->
