### PR TITLE
fix(buffer): make buffer capacity atleast defaultCapacity

### DIFF
--- a/z/buffer.go
+++ b/z/buffer.go
@@ -57,7 +57,7 @@ type Buffer struct {
 }
 
 func NewBuffer(capacity int, tag string) *Buffer {
-	if capacity == 0 {
+	if capacity < defaultCapacity {
 		capacity = defaultCapacity
 	}
 	if tag == "" {
@@ -100,7 +100,7 @@ func NewBufferTmp(dir string, capacity int) (*Buffer, error) {
 }
 
 func newBufferFile(file *os.File, capacity int) (*Buffer, error) {
-	if capacity == 0 {
+	if capacity < defaultCapacity {
 		capacity = defaultCapacity
 	}
 	mmapFile, err := OpenMmapFileUsing(file, capacity, true)

--- a/z/buffer_test.go
+++ b/z/buffer_test.go
@@ -286,3 +286,18 @@ func newTestBuffers(t *testing.T, capacity int) []*Buffer {
 
 	return bufs
 }
+
+func TestSmallBuffer(t *testing.T) {
+	buf := NewBuffer(5, "test")
+	t.Cleanup(func() {
+		require.NoError(t, buf.Release())
+	})
+	// Write something to buffer so sort actually happens.
+	buf.WriteSlice([]byte("abc"))
+	// This test fails if the buffer has offset > currSz.
+	require.NotPanics(t, func() {
+		buf.SortSlice(func(left, right []byte) bool {
+			return true
+		})
+	})
+}


### PR DESCRIPTION
z.Buffer when initialized with `sz < 8`, it may cause crash as the buffer size is less than `offset`.
```
panic: runtime error: slice bounds out of range [:8] with capacity 7 [recovered]
	panic: runtime error: slice bounds out of range [:8] with capacity 7

goroutine 6 [running]:
testing.tRunner.func1.2(0xa09780, 0xc00084e090)
	/usr/local/go/src/testing/testing.go:1143 +0x332
testing.tRunner.func1(0xc000001b00)
	/usr/local/go/src/testing/testing.go:1146 +0x4b6
panic(0xa09780, 0xc00084e090)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
github.com/dgraph-io/ristretto/z.(*Buffer).Grow(0xc0067f60e0, 0xf)
	/home/algod/go/src/github.com/dgraph-io/ristretto/z/buffer.go:230 +0x7c5
github.com/dgraph-io/ristretto/z.(*Buffer).Write(...)
	/home/algod/go/src/github.com/dgraph-io/ristretto/z/buffer.go:495
github.com/dgraph-io/ristretto/z.(*sortHelper).sortSmall(0xc000135840, 0x8, 0x17)
	/home/algod/go/src/github.com/dgraph-io/ristretto/z/buffer.go:328 +0x305
github.com/dgraph-io/ristretto/z.(*Buffer).SortSliceBetween(0xc0001fe070, 0x8, 0x17, 0xa61b90)
	/home/algod/go/src/github.com/dgraph-io/ristretto/z/buffer.go:448 +0x453
github.com/dgraph-io/ristretto/z.(*Buffer).SortSlice(...)
	/home/algod/go/src/github.com/dgraph-io/ristretto/z/buffer.go:411
github.com/dgraph-io/badger/v3.(*DB).DropPrefixNonBlocking.func1(0xc000156001, 0xae8df0, 0xc00001c140)
	/home/algod/go/src/github.com/dgraph-io/badger/db.go:1866 +0x155
github.com/dgraph-io/badger/v3.(*DB).DropPrefixNonBlocking.func2(0xc0008561f8, 0x2, 0x2, 0xc0001fe070, 0x1)
	/home/algod/go/src/github.com/dgraph-io/badger/db.go:1935 +0x21f
github.com/dgraph-io/badger/v3.(*DB).DropPrefixNonBlocking(0xc000123b00, 0xc000850a80, 0x1, 0x1, 0x0, 0x0)
	/home/algod/go/src/github.com/dgraph-io/badger/db.go:1940 +0x24c
github.com/dgraph-io/badger/v3.TestDropPrefixNonBlockingNoError(0xc000001b00)
	/home/algod/go/src/github.com/dgraph-io/badger/db2_test.go:1150 +0x49c
testing.tRunner(0xc000001b00, 0xa62018)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/273)
<!-- Reviewable:end -->
