### PR TITLE
change expiration type from int64 to time.Time

### DIFF
--- a/store.go
+++ b/store.go
@@ -26,7 +26,7 @@ type storeItem struct {
 	key        uint64
 	conflict   uint64
 	value      interface{}
-	expiration int64
+	expiration time.Time
 }
 
 // store is the interface fulfilled by all hash map implementations in this
@@ -39,7 +39,7 @@ type store interface {
 	// Get returns the value associated with the key parameter.
 	Get(uint64, uint64) (interface{}, bool)
 	// Expiration returns the expiration time for this key.
-	Expiration(uint64) int64
+	Expiration(uint64) time.Time
 	// Set adds the key-value pair to the Map or updates the value if it's
 	// already present. The key-value pair is passed as a pointer to an
 	// item object.
@@ -82,7 +82,7 @@ func (sm *shardedMap) Get(key, conflict uint64) (interface{}, bool) {
 	return sm.shards[key%numShards].get(key, conflict)
 }
 
-func (sm *shardedMap) Expiration(key uint64) int64 {
+func (sm *shardedMap) Expiration(key uint64) time.Time {
 	return sm.shards[key%numShards].Expiration(key)
 }
 
@@ -138,13 +138,13 @@ func (m *lockedMap) get(key, conflict uint64) (interface{}, bool) {
 	}
 
 	// Handle expired items.
-	if item.expiration != 0 && time.Now().Unix() > item.expiration {
+	if !item.expiration.IsZero() && time.Now().After(item.expiration) {
 		return nil, false
 	}
 	return item.value, true
 }
 
-func (m *lockedMap) Expiration(key uint64) int64 {
+func (m *lockedMap) Expiration(key uint64) time.Time {
 	m.RLock()
 	defer m.RUnlock()
 	return m.data[key].expiration
@@ -193,7 +193,7 @@ func (m *lockedMap) Del(key, conflict uint64) (uint64, interface{}) {
 		return 0, nil
 	}
 
-	if item.expiration != 0 {
+	if !item.expiration.IsZero() {
 		m.em.del(key, item.expiration)
 	}
 

--- a/store_test.go
+++ b/store_test.go
@@ -156,7 +156,7 @@ func TestStoreCollision(t *testing.T) {
 func TestStoreExpiration(t *testing.T) {
 	s := newStore()
 	key, conflict := z.KeyToHash(1)
-	expiration := time.Now().Add(time.Second).Unix()
+	expiration := time.Now().Add(time.Second)
 	i := Item{
 		Key:        key,
 		Conflict:   conflict,
@@ -175,12 +175,12 @@ func TestStoreExpiration(t *testing.T) {
 
 	_, ok = s.Get(key, conflict)
 	require.False(t, ok)
-	require.Equal(t, int64(0), s.Expiration(key))
+	require.True(t, s.Expiration(key).IsZero())
 
 	// missing item
 	key, _ = z.KeyToHash(4340958203495)
 	ttl = s.Expiration(key)
-	require.Equal(t, int64(0), ttl)
+	require.True(t, ttl.IsZero())
 }
 
 func BenchmarkStoreGet(b *testing.B) {

--- a/ttl.go
+++ b/ttl.go
@@ -26,11 +26,11 @@ var (
 	bucketDurationSecs = int64(5)
 )
 
-func storageBucket(t int64) int64 {
-	return (t / bucketDurationSecs) + 1
+func storageBucket(t time.Time) int64 {
+	return (t.Unix() / bucketDurationSecs) + 1
 }
 
-func cleanupBucket(t int64) int64 {
+func cleanupBucket(t time.Time) int64 {
 	// The bucket to cleanup is always behind the storage bucket by one so that
 	// no elements in that bucket (which might not have expired yet) are deleted.
 	return storageBucket(t) - 1
@@ -51,13 +51,13 @@ func newExpirationMap() *expirationMap {
 	}
 }
 
-func (m *expirationMap) add(key, conflict uint64, expiration int64) {
+func (m *expirationMap) add(key, conflict uint64, expiration time.Time) {
 	if m == nil {
 		return
 	}
 
 	// Items that don't expire don't need to be in the expiration map.
-	if expiration == 0 {
+	if expiration.IsZero() {
 		return
 	}
 
@@ -73,7 +73,7 @@ func (m *expirationMap) add(key, conflict uint64, expiration int64) {
 	b[key] = conflict
 }
 
-func (m *expirationMap) update(key, conflict uint64, oldExpTime, newExpTime int64) {
+func (m *expirationMap) update(key, conflict uint64, oldExpTime, newExpTime time.Time) {
 	if m == nil {
 		return
 	}
@@ -96,7 +96,7 @@ func (m *expirationMap) update(key, conflict uint64, oldExpTime, newExpTime int6
 	newBucket[key] = conflict
 }
 
-func (m *expirationMap) del(key uint64, expiration int64) {
+func (m *expirationMap) del(key uint64, expiration time.Time) {
 	if m == nil {
 		return
 	}
@@ -120,7 +120,7 @@ func (m *expirationMap) cleanup(store store, policy policy, onEvict itemCallback
 	}
 
 	m.Lock()
-	now := time.Now().Unix()
+	now := time.Now()
 	bucketNum := cleanupBucket(now)
 	keys := m.buckets[bucketNum]
 	delete(m.buckets, bucketNum)
@@ -128,7 +128,7 @@ func (m *expirationMap) cleanup(store store, policy policy, onEvict itemCallback
 
 	for key, conflict := range keys {
 		// Sanity check. Verify that the store agrees that this key is expired.
-		if store.Expiration(key) > now {
+		if store.Expiration(key).After(now) {
 			continue
 		}
 


### PR DESCRIPTION
FIX: https://discuss.dgraph.io/t/setwithttl-doesnt-work/14192

I did `git bisect` with added test and found #195 makes this broken.

#195 has 2 changes.
1. change expiration type from time.Time to int64
2. add a flag to toggle cost calculation

I reverted 1, and the test is fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/277)
<!-- Reviewable:end -->
