### PR TITLE
Remove mmapSize check, it has wrong value on ARM64

### DIFF
--- a/z/mmap_linux.go
+++ b/z/mmap_linux.go
@@ -17,7 +17,6 @@
 package z
 
 import (
-	"fmt"
 	"os"
 	"reflect"
 	"unsafe"
@@ -41,7 +40,7 @@ func mremap(data []byte, size int) ([]byte, error) {
 	const MREMAP_MAYMOVE = 0x1
 
 	header := (*reflect.SliceHeader)(unsafe.Pointer(&data))
-	mmapAddr, mmapSize, errno := unix.Syscall6(
+	mmapAddr, _, errno := unix.Syscall6(
 		unix.SYS_MREMAP,
 		header.Data,
 		uintptr(header.Len),
@@ -52,9 +51,6 @@ func mremap(data []byte, size int) ([]byte, error) {
 	)
 	if errno != 0 {
 		return nil, errno
-	}
-	if mmapSize != uintptr(size) {
-		return nil, fmt.Errorf("mremap size mismatch: requested: %d got: %d", size, mmapSize)
 	}
 
 	header.Data = mmapAddr


### PR DESCRIPTION
In this statement:
`mmapAddr, mmapSize, errno := unix.Syscall6(unix.SYS_MREMAP,...)`

`mmapSize` - it is not an allocated size, at least for ARM64 arch.
For ARM64, `mmapSize` will be equal to the old size.

Example script: https://gist.github.com/yarysh/2b4db19ebe1236f31ff6780d956628f5

I run this script on **AMD64** machine with Ubuntu 20.04, and it returns:
```
Requested size: 20
mmapAddr: 824634507264
mmapSize: 20
```

And on **ARM64** machine (Raspberry PI and AWS Graviton) with Ubuntu 20.04, it returns:
```
Requested size: 20
mmapAddr: 274878390272
mmapSize: 1024
mremap size mismatch: requested: 20 got: 1024
```

I have checked man for mremap and it describes returns as:
```
RETURN VALUE
       On  success mremap() returns a pointer to the new virtual memory area.  On error,
       the value MAP_FAILED (that is, (void *) -1) is returned, and errno is set appropriately.
```

This issue also affected **badger** on ARM64: https://discuss.dgraph.io/t/error-mremap-size-mismatch-on-arm64/15333

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/281)
<!-- Reviewable:end -->
