### PR TITLE
feat: support msync for windows

### DIFF
--- a/z/mmap_windows.go
+++ b/z/mmap_windows.go
@@ -91,6 +91,5 @@ func madvise(b []byte, readahead bool) error {
 }
 
 func msync(b []byte) error {
-	// TODO: Figure out how to do msync on Windows.
-	return nil
+	return syscall.FlushViewOfFile(uintptr(unsafe.Pointer(&b[0])), uintptr(len(b)))
 }


### PR DESCRIPTION
Hi, I encountered a windows power loss caused problem while using badger, and see that msync on windows is not supported.

I add the implementation and test it in a windows10 VM, it just works.

see:  https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-flushviewoffile

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/283)
<!-- Reviewable:end -->
