### PR TITLE
readme: include SpiceDB usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ Below is a list of known projects that use Ristretto:
 
 - [Badger](https://github.com/dgraph-io/badger) - Embeddable key-value DB in Go
 - [Dgraph](https://github.com/dgraph-io/dgraph) - Horizontally scalable and distributed GraphQL database with a graph backend
-- [Vitess](https://github.com/vitessio/vitess) - database clustering system for horizontal scaling of MySQL
+- [Vitess](https://github.com/vitessio/vitess) - Database clustering system for horizontal scaling of MySQL
+- [SpiceDB](https://github.com/authzed/spicedb) - Horizontally scalable permissions database
 
 ## FAQ
 


### PR DESCRIPTION
Hey there!

We recently launched [SpiceDB](https://github.com/authzed/spicedb) and wanted to thank all of the contributors to Ristretto. We spent some time investigating TinyLFU and were ultimately so happy to find such a great solution available to the community. We hope to contribute back anything we find in the future to keep this library awesome! This is why the Go community rocks! 🤘

I hope it'd be okay to include us in the list of known projects.

SpiceDB has a really interesting use case for Ristretto: API requests are broken down into recursive steps that are each consistently hashed and re-dispatched to a specific database instance that caches responses for that step. We effectively treat each database instance also as a shard of one distributed Ristretto cache!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/285)
<!-- Reviewable:end -->
