### PR TITLE
Fixes closing of Cache and Policy to be concurrent safe

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -90,7 +90,10 @@ type Metrics struct {
 // to the cache and policy instances.
 func (c *Cache) collectMetrics() {
 	c.Metrics = newMetrics()
-	c.policy.CollectMetrics(c.Metrics)
+	internals := c.internals
+	if internals != nil {
+		internals.policy.CollectMetrics(c.Metrics)
+	}
 }
 
 func newMetrics() *Metrics {

--- a/policy_test.go
+++ b/policy_test.go
@@ -23,7 +23,7 @@ func TestPolicyMetrics(t *testing.T) {
 
 func TestPolicyProcessItems(t *testing.T) {
 	p := newPolicy(100, 10)
-	p.itemsCh <- []uint64{1, 2, 2}
+	p.internals.itemsCh <- []uint64{1, 2, 2}
 	time.Sleep(wait)
 	p.Lock()
 	require.Equal(t, int64(2), p.admit.Estimate(2))
@@ -31,7 +31,7 @@ func TestPolicyProcessItems(t *testing.T) {
 	p.Unlock()
 
 	p.stop <- struct{}{}
-	p.itemsCh <- []uint64{3, 3, 3}
+	p.internals.itemsCh <- []uint64{3, 3, 3}
 	time.Sleep(wait)
 	p.Lock()
 	require.Equal(t, int64(0), p.admit.Estimate(3))
@@ -138,7 +138,7 @@ func TestPolicyClose(t *testing.T) {
 	p := newPolicy(100, 10)
 	p.Add(1, 1)
 	p.Close()
-	p.itemsCh <- []uint64{1}
+	p.internals.itemsCh <- []uint64{1}
 }
 
 func TestPushAfterClose(t *testing.T) {


### PR DESCRIPTION
Before this change, calling Close on the cache while a Set call is in progress could occasionally result in a panic when the Set method tried to write to the (now closed) `setBuf` channel. This commit changes Cache and Policy to keep references to the written-to channels in an `internals` struct, which is nil-ed out on close and checked in each call site, ensuring that nothing is attempting to write to a closed channel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/286)
<!-- Reviewable:end -->
