### PR TITLE
fix runtime error: index out of range for !amd64 env

### DIFF
--- a/z/simd/search.go
+++ b/z/simd/search.go
@@ -20,7 +20,7 @@ package simd
 
 // Search uses the Clever search to find the correct key.
 func Search(xs []uint64, k uint64) int16 {
-	if len(xs) < 8 {
+	if len(xs) < 8 || (len(xs) % 8 != 0) {
 		return Naive(xs, k)
 	}
 	var twos, pk [4]uint64


### PR DESCRIPTION
fix `runtime error: index out of range`  in non-amd64 (arm64) env

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/287)
<!-- Reviewable:end -->
