### PR TITLE
z: use zeebo/xxh3 instead of cespare/xxhash/v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/dgraph-io/ristretto
 go 1.12
 
 require (
-	github.com/cespare/xxhash/v2 v2.1.1
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
 	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.4.0
+	github.com/zeebo/xxh3 v1.0.1
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
-github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -9,6 +7,8 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
+github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -16,6 +16,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/zeebo/xxh3 v1.0.1 h1:FMSRIbkrLikb/0hZxmltpg84VkqDAT5M8ufXynuhXsI=
+github.com/zeebo/xxh3 v1.0.1/go.mod h1:8VHV24/3AZLn3b6Mlp/KuC33LWH687Wq6EnziEB+rsA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/z/z.go
+++ b/z/z.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/cespare/xxhash/v2"
+	"github.com/zeebo/xxh3"
 )
 
 // TODO: Figure out a way to re-use memhash for the second uint64 hash, we
@@ -39,9 +39,9 @@ func KeyToHash(key interface{}) (uint64, uint64) {
 	case uint64:
 		return k, 0
 	case string:
-		return MemHashString(k), xxhash.Sum64String(k)
+		return MemHashString(k), xxh3.HashString(k)
 	case []byte:
-		return MemHash(k), xxhash.Sum64(k)
+		return MemHash(k), xxh3.Hash(k)
 	case byte:
 		return uint64(k), 0
 	case int:

--- a/z/z_test.go
+++ b/z/z_test.go
@@ -17,6 +17,7 @@
 package z
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -104,4 +105,45 @@ func TestZeroOut(t *testing.T) {
 
 	ZeroOut(dst, 0, len(dst))
 	check(dst, 0x00)
+}
+
+func BenchmarkKeyToHashBytes(b *testing.B) {
+	bench := []interface{}{
+		[]byte("foo"),
+		[]byte("barbaz"),
+		[]byte("quxquuxquuz"),
+		[]byte("corgegraultgarplywaldo"),
+	}
+	benchmarkKeyToHash(b, bench)
+}
+
+func BenchmarkKeyToHashString(b *testing.B) {
+	bench := []interface{}{
+		"foo",
+		"barbaz",
+		"quxquuxquuz",
+		"corgegraultgarplywaldo",
+	}
+	benchmarkKeyToHash(b, bench)
+}
+
+var key, conflict uint64
+
+func benchmarkKeyToHash(b *testing.B, bench []interface{}) {
+	for _, bb := range bench {
+		b.Run(fmt.Sprintf("%s", bb), func(b *testing.B) {
+			switch bb := bb.(type) {
+			case []byte:
+				b.SetBytes(int64(len(bb)))
+			case string:
+				b.SetBytes(int64(len(bb)))
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				key, conflict = KeyToHash(bb)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Use zeebo/xxh3 instead of cespare/xxhash/v2.

```
darwin/amd64 (might be disabled AVX512 even if Xeon, cuz darwin kernel bug)
name                                       old time/op    new time/op    delta
KeyToHashBytes/foo-20                        9.08ns ± 1%    7.96ns ± 1%  -12.39%  (p=0.008 n=5+5)
KeyToHashBytes/barbaz-20                     9.35ns ± 0%    8.05ns ± 2%  -13.91%  (p=0.008 n=5+5)
KeyToHashBytes/quxquuxquuz-20                10.1ns ± 0%     8.1ns ± 4%  -19.69%  (p=0.008 n=5+5)
KeyToHashBytes/corgegraultgarplywaldo-20     11.0ns ± 4%     9.4ns ± 3%  -14.64%  (p=0.008 n=5+5)
KeyToHashString/foo-20                       11.1ns ± 1%     7.5ns ± 3%  -32.18%  (p=0.008 n=5+5)
KeyToHashString/barbaz-20                    11.2ns ± 2%     7.7ns ± 1%  -31.48%  (p=0.008 n=5+5)
KeyToHashString/quxquuxquuz-20               12.3ns ± 0%     7.5ns ± 1%  -38.90%  (p=0.008 n=5+5)
KeyToHashString/corgegraultgarplywaldo-20    13.7ns ± 0%     8.6ns ± 0%  -36.79%  (p=0.008 n=5+5)

name                                       old speed      new speed      delta
KeyToHashBytes/foo-20                       330MB/s ± 1%   377MB/s ± 1%  +14.14%  (p=0.008 n=5+5)
KeyToHashBytes/barbaz-20                    642MB/s ± 0%   746MB/s ± 2%  +16.17%  (p=0.008 n=5+5)
KeyToHashBytes/quxquuxquuz-20              1.09GB/s ± 0%  1.36GB/s ± 4%  +24.60%  (p=0.008 n=5+5)
KeyToHashBytes/corgegraultgarplywaldo-20   1.99GB/s ± 4%  2.33GB/s ± 3%  +17.12%  (p=0.008 n=5+5)
KeyToHashString/foo-20                      271MB/s ± 1%   399MB/s ± 3%  +47.53%  (p=0.008 n=5+5)
KeyToHashString/barbaz-20                   537MB/s ± 2%   784MB/s ± 1%  +45.93%  (p=0.008 n=5+5)
KeyToHashString/quxquuxquuz-20              894MB/s ± 0%  1463MB/s ± 1%  +63.67%  (p=0.008 n=5+5)
KeyToHashString/corgegraultgarplywaldo-20  1.61GB/s ± 0%  2.55GB/s ± 0%  +58.21%  (p=0.008 n=5+5)

linux/amd64 (enabled AVX512)
name                                       old time/op    new time/op    delta
KeyToHashBytes/foo-30                        10.4ns ± 0%     8.6ns ± 0%  -17.72%  (p=0.008 n=5+5)
KeyToHashBytes/barbaz-30                     10.4ns ± 0%     8.9ns ± 0%  -14.69%  (p=0.016 n=4+5)
KeyToHashBytes/quxquuxquuz-30                11.6ns ± 0%     8.9ns ± 1%  -23.70%  (p=0.008 n=5+5)
KeyToHashBytes/corgegraultgarplywaldo-30     12.6ns ± 0%    10.5ns ± 0%  -16.68%  (p=0.008 n=5+5)
KeyToHashString/foo-30                       12.9ns ± 0%     8.3ns ± 0%  -35.94%  (p=0.008 n=5+5)
KeyToHashString/barbaz-30                    12.8ns ± 1%     8.6ns ± 1%  -32.54%  (p=0.008 n=5+5)
KeyToHashString/quxquuxquuz-30               14.2ns ± 0%     8.9ns ± 0%  -37.52%  (p=0.016 n=4+5)
KeyToHashString/corgegraultgarplywaldo-30    15.7ns ± 0%    10.0ns ± 1%  -36.75%  (p=0.008 n=5+5)

name                                       old speed      new speed      delta
KeyToHashBytes/foo-30                       288MB/s ± 0%   350MB/s ± 0%  +21.53%  (p=0.008 n=5+5)
KeyToHashBytes/barbaz-30                    577MB/s ± 0%   676MB/s ± 0%  +17.15%  (p=0.008 n=5+5)
KeyToHashBytes/quxquuxquuz-30               948MB/s ± 0%  1242MB/s ± 1%  +31.10%  (p=0.008 n=5+5)
KeyToHashBytes/corgegraultgarplywaldo-30   1.75GB/s ± 0%  2.10GB/s ± 1%  +20.02%  (p=0.008 n=5+5)
KeyToHashString/foo-30                      232MB/s ± 0%   362MB/s ± 0%  +56.08%  (p=0.008 n=5+5)
KeyToHashString/barbaz-30                   469MB/s ± 1%   696MB/s ± 1%  +48.22%  (p=0.008 n=5+5)
KeyToHashString/quxquuxquuz-30              776MB/s ± 0%  1242MB/s ± 0%  +60.09%  (p=0.008 n=5+5)
KeyToHashString/corgegraultgarplywaldo-30  1.40GB/s ± 0%  2.21GB/s ± 1%  +58.09%  (p=0.008 n=5+5)
```

benchmark result:
- https://perf.golang.org/search?q=upload:20211112.4
- https://perf.golang.org/search?q=upload:20211112.5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/ristretto/291)
<!-- Reviewable:end -->
