### PR TITLE
fix(z): Address inconsistent mremap return arguments with arm64

### DIFF
--- a/z/mmap_linux.go
+++ b/z/mmap_linux.go
@@ -17,9 +17,7 @@
 package z
 
 import (
-	"fmt"
 	"os"
-	"reflect"
 	"unsafe"
 
 	"golang.org/x/sys/unix"

--- a/z/mmap_linux.go
+++ b/z/mmap_linux.go
@@ -35,34 +35,6 @@ func mmap(fd *os.File, writable bool, size int64) ([]byte, error) {
 	return unix.Mmap(int(fd.Fd()), 0, int(size), mtype, unix.MAP_SHARED)
 }
 
-// mremap is a Linux-specific system call to remap pages in memory. This can be used in place of munmap + mmap.
-func mremap(data []byte, size int) ([]byte, error) {
-	// taken from <https://github.com/torvalds/linux/blob/f8394f232b1eab649ce2df5c5f15b0e528c92091/include/uapi/linux/mman.h#L8>
-	const MREMAP_MAYMOVE = 0x1
-
-	header := (*reflect.SliceHeader)(unsafe.Pointer(&data))
-	mmapAddr, mmapSize, errno := unix.Syscall6(
-		unix.SYS_MREMAP,
-		header.Data,
-		uintptr(header.Len),
-		uintptr(size),
-		uintptr(MREMAP_MAYMOVE),
-		0,
-		0,
-	)
-	if errno != 0 {
-		return nil, errno
-	}
-	if mmapSize != uintptr(size) {
-		return nil, fmt.Errorf("mremap size mismatch: requested: %d got: %d", size, mmapSize)
-	}
-
-	header.Data = mmapAddr
-	header.Cap = size
-	header.Len = size
-	return data, nil
-}
-
 // munmap unmaps a previously mapped slice.
 //
 // unix.Munmap maintains an internal list of mmapped addresses, and only calls munmap

--- a/z/mremap_linux.go
+++ b/z/mremap_linux.go
@@ -1,3 +1,5 @@
+// +build !arm64
+
 /*
  * Copyright 2020 Dgraph Labs, Inc. and Contributors
  *

--- a/z/mremap_linux.go
+++ b/z/mremap_linux.go
@@ -28,6 +28,7 @@ import (
 
 // mremap is a Linux-specific system call to remap pages in memory. This can be used in place of munmap + mmap.
 func mremap(data []byte, size int) ([]byte, error) {
+	//nolint:lll
 	// taken from <https://github.com/torvalds/linux/blob/f8394f232b1eab649ce2df5c5f15b0e528c92091/include/uapi/linux/mman.h#L8>
 	const MREMAP_MAYMOVE = 0x1
 

--- a/z/mremap_linux_amd64.go
+++ b/z/mremap_linux_amd64.go
@@ -18,7 +18,6 @@ package z
 
 import (
 	"fmt"
-	"os"
 	"reflect"
 	"unsafe"
 

--- a/z/mremap_linux_amd64.go
+++ b/z/mremap_linux_amd64.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package z
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// mremap is a Linux-specific system call to remap pages in memory. This can be used in place of munmap + mmap.
+func mremap(data []byte, size int) ([]byte, error) {
+	// taken from <https://github.com/torvalds/linux/blob/f8394f232b1eab649ce2df5c5f15b0e528c92091/include/uapi/linux/mman.h#L8>
+	const MREMAP_MAYMOVE = 0x1
+
+	header := (*reflect.SliceHeader)(unsafe.Pointer(&data))
+	mmapAddr, mmapSize, errno := unix.Syscall6(
+		unix.SYS_MREMAP,
+		header.Data,
+		uintptr(header.Len),
+		uintptr(size),
+		uintptr(MREMAP_MAYMOVE),
+		0,
+		0,
+	)
+	if errno != 0 {
+		return nil, errno
+	}
+	if mmapSize != uintptr(size) {
+		return nil, fmt.Errorf("mremap size mismatch: requested: %d got: %d", size, mmapSize)
+	}
+
+	header.Data = mmapAddr
+	header.Cap = size
+	header.Len = size
+	return data, nil
+}

--- a/z/mremap_linux_arm64.go
+++ b/z/mremap_linux_arm64.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package z
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// mremap is a Linux-specific system call to remap pages in memory. This can be used in place of munmap + mmap.
+func mremap(data []byte, size int) ([]byte, error) {
+	// taken from <https://github.com/torvalds/linux/blob/f8394f232b1eab649ce2df5c5f15b0e528c92091/include/uapi/linux/mman.h#L8>
+	const MREMAP_MAYMOVE = 0x1
+
+	header := (*reflect.SliceHeader)(unsafe.Pointer(&data))
+	mmapAddr, _, errno := unix.Syscall6(
+		unix.SYS_MREMAP,
+		header.Data,
+		uintptr(header.Len),
+		uintptr(size),
+		uintptr(MREMAP_MAYMOVE),
+		0,
+		0,
+	)
+	if errno != 0 {
+		return nil, errno
+	}
+
+	header.Data = mmapAddr
+	header.Cap = size
+	header.Len = size
+	return data, nil
+}

--- a/z/mremap_linux_arm64.go
+++ b/z/mremap_linux_arm64.go
@@ -25,6 +25,7 @@ import (
 
 // mremap is a Linux-specific system call to remap pages in memory. This can be used in place of munmap + mmap.
 func mremap(data []byte, size int) ([]byte, error) {
+	//nolint:lll
 	// taken from <https://github.com/torvalds/linux/blob/f8394f232b1eab649ce2df5c5f15b0e528c92091/include/uapi/linux/mman.h#L8>
 	const MREMAP_MAYMOVE = 0x1
 

--- a/z/mremap_linux_arm64.go
+++ b/z/mremap_linux_arm64.go
@@ -29,6 +29,8 @@ func mremap(data []byte, size int) ([]byte, error) {
 	const MREMAP_MAYMOVE = 0x1
 
 	header := (*reflect.SliceHeader)(unsafe.Pointer(&data))
+	// For ARM64, the second return argument for SYS_MREMAP is inconsistent (prior allocated size) with
+	// other architectures, which return the size allocated
 	mmapAddr, _, errno := unix.Syscall6(
 		unix.SYS_MREMAP,
 		header.Data,

--- a/z/mremap_linux_arm64.go
+++ b/z/mremap_linux_arm64.go
@@ -17,8 +17,6 @@
 package z
 
 import (
-	"fmt"
-	"os"
 	"reflect"
 	"unsafe"
 


### PR DESCRIPTION
This PR adds a specific arm64 implementation for the `mremap` function which ignores the second return argument from the syscall. **All other Linux implementations are unchanged.**

This PR reworks [an earlier PR](https://github.com/dgraph-io/ristretto/pull/281) so that the functionality on non-arm64 platforms remains the same.

Tested on Linux amd64 and Linux arm64.

