### PR TITLE
Chore(CI): fixing linting in sketch.go

### DIFF
--- a/sketch.go
+++ b/sketch.go
@@ -53,7 +53,8 @@ func newCmSketch(numCounters int64) *cmSketch {
 	numCounters = next2Power(numCounters)
 	sketch := &cmSketch{mask: uint64(numCounters - 1)}
 	// Initialize rows of counters and seeds.
-	source := rand.New(rand.NewSource(time.Now().UnixNano()))
+	// Cryptographic precision not needed
+	source := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec
 	for i := 0; i < cmDepth; i++ {
 		sketch.seed[i] = source.Uint64()
 		sketch.rows[i] = newCmRow(numCounters)


### PR DESCRIPTION
## Problem

Lint tests were failing in sketch.go.

## Solution

We add nolint directive.