### PR TITLE
chore(docs): Include SpiceDB in the list of projects using Ristretto (#285)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ Below is a list of known projects that use Ristretto:
 
 - [Badger](https://github.com/dgraph-io/badger) - Embeddable key-value DB in Go
 - [Dgraph](https://github.com/dgraph-io/dgraph) - Horizontally scalable and distributed GraphQL database with a graph backend
-- [Vitess](https://github.com/vitessio/vitess) - database clustering system for horizontal scaling of MySQL
+- [Vitess](https://github.com/vitessio/vitess) - Database clustering system for horizontal scaling of MySQL
+- [SpiceDB](https://github.com/authzed/spicedb) - Horizontally scalable permissions database
 
 ## FAQ
 


### PR DESCRIPTION
## Problem

Readme was updated in master branch.  We cherry pick this commit into main.

## Solution

Cherry pick from [PR 285.](https://github.com/dgraph-io/ristretto/pull/285)

## Original Commit Info

Include SpiceDB in the list of projects using Ristretto.

Signed-off-by: Jimmy Zelinskie <jimmy@zelinskie.com>
(cherry picked from commit 55e7615b73e57b2762a402aceb64088dc99f7cc0)

