### PR TITLE
chore(ci): pin runner to ubuntu 20.04

### DIFF
--- a/.github/workflows/ci-ristretto-lint.yml
+++ b/.github/workflows/ci-ristretto-lint.yml
@@ -24,4 +24,3 @@ jobs:
           version: v1.48
           only-new-issues: true
           args: --timeout=10m
-          skip-go-installation: true

--- a/.github/workflows/ci-ristretto-lint.yml
+++ b/.github/workflows/ci-ristretto-lint.yml
@@ -21,7 +21,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.36
+          version: v1.48
           only-new-issues: true
           args: --timeout=10m
           skip-go-installation: true

--- a/.github/workflows/ci-ristretto-lint.yml
+++ b/.github/workflows/ci-ristretto-lint.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   go-lint:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: golang-lint

--- a/.github/workflows/ci-ristretto-lint.yml
+++ b/.github/workflows/ci-ristretto-lint.yml
@@ -11,14 +11,14 @@ on:
 jobs:
   go-lint:
     name: lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: golang-lint
         env:
           # prevent OOM
           GOGC: 10
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.36

--- a/.github/workflows/ci-ristretto-tests.yml
+++ b/.github/workflows/ci-ristretto-tests.yml
@@ -10,7 +10,7 @@ on:
     - cron: "30 * * * *"
 jobs:
   ristretto-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Get Go Version

--- a/.github/workflows/ci-ristretto-tests.yml
+++ b/.github/workflows/ci-ristretto-tests.yml
@@ -16,8 +16,7 @@ jobs:
       - name: Get Go Version
         run: |
           #!/bin/bash
-          DEFAULT_VERSION="1.17"
-          GOVERSION=$({ [ -f .go-version ] && cat .go-version; } || echo $DEFAULT_VERSION)
+          GOVERSION=$({ [ -f .go-version ] && cat .go-version; })
           echo "GOVERSION=$GOVERSION" >> $GITHUB_ENV
       - name: Setup Go
         uses: actions/setup-go@v3


### PR DESCRIPTION
## Problem

Lint tests and CI tests were failing.

## Solution

Pin ristretto test runner to Ubuntu 20.04, and bump up linter dependencies.