### PR TITLE
`docs(Readme)`: Use new Wait method

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ func main() {
 	cache.Set("key", "value", 1)
 	
 	// wait for value to pass through buffers
-	time.Sleep(10 * time.Millisecond)
+	cache.Wait()
 
 	value, found := cache.Get("key")
 	if !found {


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
README was using a `time.Sleep` in its example

## Solution
PR updates it to use the new `Wait()` method.