### PR TITLE
chore(ci): resolve community PR failures

### DIFF
--- a/.github/workflows/ci-ristretto-tests.yml
+++ b/.github/workflows/ci-ristretto-tests.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main 
-  pull_request:
+  pull_request_target:
     branches:
       - main 
   schedule:


### PR DESCRIPTION
Goveralls was failing on community PR's.  See https://github.com/dgraph-io/badger/pull/1894

Resolves: https://github.com/coverallsapp/github-action/issues/150