### PR TITLE
docs: format example on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ Ristretto is production-ready. See [Projects using Ristretto](#projects-using-ri
 ### Example
 
 ```go
+package main
+
+import (
+	"fmt"
+	"github.com/dgraph-io/ristretto"
+)
+
 func main() {
 	cache, err := ristretto.NewCache(&ristretto.Config{
 		NumCounters: 1e7,     // number of keys to track frequency of (10M).
@@ -69,15 +76,18 @@ func main() {
 
 	// set a value with a cost of 1
 	cache.Set("key", "value", 1)
-	
+
 	// wait for value to pass through buffers
 	cache.Wait()
 
+	// get value from cache
 	value, found := cache.Get("key")
 	if !found {
 		panic("missing value")
 	}
 	fmt.Println(value)
+
+	// del value from cache
 	cache.Del("key")
 }
 ```

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/dgraph-io/ristretto"
 )
 


### PR DESCRIPTION
## what

format code example on readme.md.

The previous examples were missing package references. Now change to a complete example. If you want to test this library, just run it directly.