### PR TITLE
`feat(configurable cleanup ticker)`: add config for cleanup ticker duration

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -135,6 +135,8 @@ type Config struct {
 	// cost passed to set is not using bytes as units. Keep in mind that setting
 	// this to true will increase the memory usage.
 	IgnoreInternalCost bool
+	// TtlTickerDurationInSec set the value of time ticker for cleanup keys on ttl
+	TtlTickerDurationInSec int64
 }
 
 type itemFlag byte
@@ -165,6 +167,8 @@ func NewCache(config *Config) (*Cache, error) {
 		return nil, errors.New("MaxCost can't be zero")
 	case config.BufferItems == 0:
 		return nil, errors.New("BufferItems can't be zero")
+	case config.TtlTickerDurationInSec == 0:
+		config.TtlTickerDurationInSec = bucketDurationSecs
 	}
 	policy := newPolicy(config.NumCounters, config.MaxCost)
 	cache := &Cache{
@@ -176,7 +180,7 @@ func NewCache(config *Config) (*Cache, error) {
 		stop:               make(chan struct{}),
 		cost:               config.Cost,
 		ignoreInternalCost: config.IgnoreInternalCost,
-		cleanupTicker:      time.NewTicker(time.Duration(bucketDurationSecs) * time.Second / 2),
+		cleanupTicker:      time.NewTicker(time.Duration(config.TtlTickerDurationInSec) * time.Second / 2),
 	}
 	cache.onExit = func(val interface{}) {
 		if config.OnExit != nil && val != nil {


### PR DESCRIPTION
## Problem
Cleanup ticker to remove entries for expired keys taking a lot of CPU cycles around 90% in the case of pod with 1.6 CPU

## Solution
 Making the duration of the cleanup ticker configurable so users can configure it to higher values and can save on CPU cycles.