### PR TITLE
fix: cleanupTicker not being stopped

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -366,6 +366,7 @@ func (c *Cache) Close() {
 	close(c.stop)
 	close(c.setBuf)
 	c.policy.Close()
+	c.cleanupTicker.Stop()
 	c.isClosed = true
 }
 


### PR DESCRIPTION
## Problem
`cleanupTicker `that is created in `NewCache` is never stopped, which is why the code below causes a memory leak
```go
for {
	c, _ := NewCache(...)
	c.Close()
}
```

## Solution
Stop `cleanupTicker` in `Close` method.