### PR TITLE
fix: support compilation to wasip1

### DIFF
--- a/z/mmap_unix.go
+++ b/z/mmap_unix.go
@@ -1,4 +1,5 @@
-// +build !windows,!darwin,!plan9,!linux
+//go:build !windows && !darwin && !plan9 && !linux && !wasip1
+// +build !windows,!darwin,!plan9,!linux,!wasip1
 
 /*
  * Copyright 2019 Dgraph Labs, Inc. and Contributors

--- a/z/mmap_wasip1.go
+++ b/z/mmap_wasip1.go
@@ -1,0 +1,40 @@
+//go:build wasip1
+
+/*
+ * Copyright 2023 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package z
+
+import (
+	"os"
+	"syscall"
+)
+
+func mmap(fd *os.File, writeable bool, size int64) ([]byte, error) {
+	return nil, syscall.ENOSYS
+}
+
+func munmap(b []byte) error {
+	return syscall.ENOSYS
+}
+
+func madvise(b []byte, readahead bool) error {
+	return syscall.ENOSYS
+}
+
+func msync(b []byte) error {
+	return syscall.ENOSYS
+}


### PR DESCRIPTION
## Problem

I'm interested in getting ristretto to build to the new `wasip1` target, but it fails due to ristretto's assumption that the program is being compiled to a unix system where files can be mapped to memory. At this time, the `x/sys/unix` package does not consider `wasip1` to be a unix platform, and memory mapping isn't supported either when compiling to WebAssembly.

```
$ GOOS=wasip1 GOARCH=wasm gotip build
package github.com/dgraph-io/ristretto
	imports github.com/dgraph-io/ristretto/z
	imports golang.org/x/sys/unix: build constraints exclude all Go files in /go/pkg/mod/golang.org/x/sys@v0.0.0-20221010170243-090e33056c14/unix
```

## Solution

The proposed solution in this PR is to provide stubs implementations of the memory mapping functions which return `ENOSYS` to indicate that the functionalities are not available when compiled to `GOOS=wasip1`.

If I'm reading the code correctly, this means that persisting data structures to a storage medium will not be supported, but the rest of ristretto should work as expected.

I believe this to be a useful trade-off since many dependents of ristretto only use the in-memory data structures (e.g. https://github.com/DataDog/datadog-agent/blob/main/pkg/obfuscate/cache.go, which is what I'm interested in getting to compile).

A more advanced solution could be to rework the `z.Buffer` internals so the data structure can work on platforms where mapping files to memory isn't supported; however, this represents a bigger undertaking, I would like to first unblock dependencies by allowing the program to compile.

Please let me know if you have any concerns or feedback on the change!