### PR TITLE
`fix(OnEvict)`: Set missing Expiration field on evicted items

### DIFF
--- a/ttl.go
+++ b/ttl.go
@@ -127,8 +127,9 @@ func (m *expirationMap) cleanup(store store, policy policy, onEvict itemCallback
 	m.Unlock()
 
 	for key, conflict := range keys {
+		expr := store.Expiration(key)
 		// Sanity check. Verify that the store agrees that this key is expired.
-		if store.Expiration(key).After(now) {
+		if expr.After(now) {
 			continue
 		}
 
@@ -138,9 +139,10 @@ func (m *expirationMap) cleanup(store store, policy policy, onEvict itemCallback
 
 		if onEvict != nil {
 			onEvict(&Item{Key: key,
-				Conflict: conflict,
-				Value:    value,
-				Cost:     cost,
+				Conflict:   conflict,
+				Value:      value,
+				Cost:       cost,
+				Expiration: expr,
 			})
 		}
 	}


### PR DESCRIPTION
On our use case we need to rely on expiration timestamps but we realized that they return zero timestamps. Our assumption is that this is due to a bug and not by design.
## Problem
When `OnEvict` callback is executed `Item` does not have `Expiration` field set. Considering it is a public field this needs to be set and available.

## Solution
Initialize `Expiration` field before calling the `onEvict` callback