### PR TITLE
chore(ci): separate out coverage report workflow

### DIFF
--- a/.github/workflows/ci-aqua-security-trivy-tests.yml
+++ b/.github/workflows/ci-aqua-security-trivy-tests.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "0 * * * *"
+    - cron: "1 * * * *"
 jobs:
   build:
     name: trivy-tests

--- a/.github/workflows/ci-ristretto-lint.yml
+++ b/.github/workflows/ci-ristretto-lint.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "0 * * * *"
+    - cron: "1 * * * *"
 jobs:
   go-lint:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-ristretto-report-coverage.yml
+++ b/.github/workflows/ci-ristretto-report-coverage.yml
@@ -7,7 +7,7 @@ on:
     types:
       - completed
 jobs:
-  upload:
+  report-coverage:
     runs-on: ubuntu-20.04
     if: >
       github.event.workflow_run.event == 'pull_request' &&

--- a/.github/workflows/ci-ristretto-report-coverage.yml
+++ b/.github/workflows/ci-ristretto-report-coverage.yml
@@ -1,0 +1,42 @@
+name: ci-ristretto-report-coverage
+# this workflow has access to repository secrets
+# separate workflow required to sanitize input from community PR's
+on:
+  workflow_run:
+    workflows: ["ci-ristretto-tests"]
+    types:
+      - completed
+jobs:
+  upload:
+    runs-on: ubuntu-20.04
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: 'Download coverage profile'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "covprofile"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/covprofile.zip', Buffer.from(download.data));
+      - run: unzip covprofile.zip
+      - name: Install Goveralls
+        run: go install github.com/mattn/goveralls@latest
+      - name: Send Coverage Results
+        env:
+          COVERALLS_TOKEN: ${{ secrets.COVERALLSIO_TOKEN }}
+        run: goveralls -coverprofile=covprofile

--- a/.github/workflows/ci-ristretto-report-coverage.yml
+++ b/.github/workflows/ci-ristretto-report-coverage.yml
@@ -10,8 +10,9 @@ jobs:
   report-coverage:
     runs-on: ubuntu-20.04
     if: >
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success') ||
+      github.event.workflow_run.event == 'push'
     steps:
       - name: 'Download coverage profile'
         uses: actions/github-script@v3.1.0

--- a/.github/workflows/ci-ristretto-report-coverage.yml
+++ b/.github/workflows/ci-ristretto-report-coverage.yml
@@ -10,10 +10,13 @@ jobs:
   report-coverage:
     runs-on: ubuntu-20.04
     if: >
-      (github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success') ||
-      github.event.workflow_run.event == 'push'
+      (github.event.workflow_run.event == 'pull_request' ||
+      github.event.workflow_run.event == 'push' ) &&
+      github.event.workflow_run.conclusion == 'success'
     steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
       - name: 'Download coverage profile'
         uses: actions/github-script@v3.1.0
         with:
@@ -35,9 +38,9 @@ jobs:
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/covprofile.zip', Buffer.from(download.data));
       - run: unzip covprofile.zip
-      - name: Install Goveralls
-        run: go install github.com/mattn/goveralls@latest
-      - name: Send Coverage Results
+      - name: Send coverage
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLSIO_TOKEN }}
-        run: goveralls -coverprofile=covprofile
+        uses: shogo82148/actions-goveralls@v1
+        with:
+          path-to-profile: ./covprofile

--- a/.github/workflows/ci-ristretto-tests.yml
+++ b/.github/workflows/ci-ristretto-tests.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     branches:
       - main
   schedule:
@@ -24,10 +24,9 @@ jobs:
           go-version: ${{ env.GOVERSION }}
       - name: Run Unit Tests
         run: go test -race -covermode atomic -coverprofile=covprofile ./...
-      - name: Install Goveralls
-        run: go install github.com/mattn/goveralls@latest
-      - name: Send Coverage Results
-        env:
-          COVERALLS_TOKEN: ${{ secrets.COVERALLSIO_TOKEN }}
-        run: goveralls -coverprofile=covprofile
+      - name: Save coverage profile
+        uses: actions/upload-artifact@v2
+        with:
+          name: covprofile
+          path: ./covprofile
 

--- a/.github/workflows/ci-ristretto-tests.yml
+++ b/.github/workflows/ci-ristretto-tests.yml
@@ -29,4 +29,3 @@ jobs:
         with:
           name: covprofile
           path: ./covprofile
-

--- a/.github/workflows/ci-ristretto-tests.yml
+++ b/.github/workflows/ci-ristretto-tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run Unit Tests
         run: go test -timeout=20m -race -covermode atomic -coverprofile=covprofile ./...
       - name: Save coverage profile
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: covprofile
           path: ./covprofile

--- a/.github/workflows/ci-ristretto-tests.yml
+++ b/.github/workflows/ci-ristretto-tests.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           go-version: ${{ env.GOVERSION }}
       - name: Run Unit Tests
-        run: go test -race -covermode atomic -coverprofile=covprofile ./...
+        run: go test -timeout=20m -race -covermode atomic -coverprofile=covprofile ./...
       - name: Save coverage profile
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci-ristretto-tests.yml
+++ b/.github/workflows/ci-ristretto-tests.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "30 * * * *"
+    - cron: "31 * * * *"
 jobs:
   ristretto-tests:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Current workflow is broken and not checking out the expected code (i.e. it is checking out target branch as opposed to PR and not reflecting changes made).  This is due to the default behavior of `pull_request_target`.  While it is possible to checkout the PR code, this creates a security vulnerability since untrusted code will be run automatically without being sanitized.  This PR will split off the part of the workflow that requires access to secrets (i.e. coverage reporting) from the part that runs the tests and uses `pull_request` which has the expected behavior of checking out the merge commit.  Thus only sanitized output (i.e. the coverprofile) from community PR's will enter the privileged workflow.

We also edit the cron job frequency to reset the email notifications and stop the ghost action jobs.

Note: CI is failing due to a timeout that this PR addresses.