### PR TITLE
Fix build with GOOS=js GOARCH=wasm

### DIFF
--- a/z/mmap_js.go
+++ b/z/mmap_js.go
@@ -1,0 +1,40 @@
+//go:build js
+
+/*
+ * Copyright 2023 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package z
+
+import (
+	"os"
+	"syscall"
+)
+
+func mmap(fd *os.File, writeable bool, size int64) ([]byte, error) {
+	return nil, syscall.ENOSYS
+}
+
+func munmap(b []byte) error {
+	return syscall.ENOSYS
+}
+
+func madvise(b []byte, readahead bool) error {
+	return syscall.ENOSYS
+}
+
+func msync(b []byte) error {
+	return syscall.ENOSYS
+}

--- a/z/mmap_linux.go
+++ b/z/mmap_linux.go
@@ -1,3 +1,6 @@
+//go:build !js
+// +build !js
+
 /*
  * Copyright 2020 Dgraph Labs, Inc. and Contributors
  *

--- a/z/mmap_unix.go
+++ b/z/mmap_unix.go
@@ -1,5 +1,5 @@
-//go:build !windows && !darwin && !plan9 && !linux && !wasip1
-// +build !windows,!darwin,!plan9,!linux,!wasip1
+//go:build !windows && !darwin && !plan9 && !linux && !wasip1 && !js
+// +build !windows,!darwin,!plan9,!linux,!wasip1,!js
 
 /*
  * Copyright 2019 Dgraph Labs, Inc. and Contributors

--- a/z/mremap_nosize.go
+++ b/z/mremap_nosize.go
@@ -1,6 +1,7 @@
-//go:build (arm64 || arm) && linux
+//go:build (arm64 || arm) && linux && !js
 // +build arm64 arm
 // +build linux
+// +build !js
 
 /*
  * Copyright 2020 Dgraph Labs, Inc. and Contributors

--- a/z/mremap_size.go
+++ b/z/mremap_size.go
@@ -1,5 +1,5 @@
-//go:build linux && !arm64 && !arm
-// +build linux,!arm64,!arm
+//go:build linux && !arm64 && !arm && !js
+// +build linux,!arm64,!arm,!js
 
 /*
  * Copyright 2020 Dgraph Labs, Inc. and Contributors


### PR DESCRIPTION
GOOS=js GOARCH=wasm gb ./...

Previously failed with errors importing x/sys/unix.

Fixed by adding the appropriate build tags.