### PR TITLE
stop using rand.Seed()

### DIFF
--- a/ttl.go
+++ b/ttl.go
@@ -143,7 +143,7 @@ func (m *expirationMap[V]) cleanup(store store[V], policy policy[V], onEvict fun
 		for key, conflict := range keys {
 			expr := store.Expiration(key)
 			// Sanity check. Verify that the store agrees that this key is expired.
-			if store.Expiration(key).After(now) {
+			if expr.After(now) {
 				continue
 			}
 

--- a/z/allocator.go
+++ b/z/allocator.go
@@ -56,9 +56,7 @@ func init() {
 	allocs = make(map[uint64]*Allocator)
 
 	// Set up a unique Ref per process.
-	rand.Seed(time.Now().UnixNano())
-	allocRef = uint64(rand.Int63n(1<<16)) << 48 //nolint:gosec // cryptographic precision not needed
-
+	allocRef = uint64(rand.Int63n(1<<16)) << 48
 	calculatedLog2 = make([]int, 1025)
 	for i := 1; i <= 1024; i++ {
 		calculatedLog2[i] = int(math.Log2(float64(i)))

--- a/z/buffer_test.go
+++ b/z/buffer_test.go
@@ -24,13 +24,11 @@ import (
 	"math/rand"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestBuffer(t *testing.T) {
-	rand.Seed(time.Now().Unix())
 	const capacity = 512
 	buffers := newTestBuffers(t, capacity)
 
@@ -61,7 +59,6 @@ func TestBuffer(t *testing.T) {
 }
 
 func TestBufferWrite(t *testing.T) {
-	rand.Seed(time.Now().Unix())
 	const capacity = 32
 	buffers := newTestBuffers(t, capacity)
 


### PR DESCRIPTION
From math/rand/rand.go:
As of Go 1.20 there is no reason to call Seed with a random value.