### PR TITLE
Fix code scanning alert no. 9: Incorrect conversion between integer types

### DIFF
--- a/z/flags.go
+++ b/z/flags.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"math"
 
 	"github.com/pkg/errors"
 )
@@ -186,6 +187,9 @@ func (sf *SuperFlag) GetDuration(opt string) time.Duration {
 		val = strings.Replace(val, "d", "", 1)
 		days, err := strconv.ParseUint(val, 0, 64)
 		if err != nil {
+			return time.Duration(0)
+		}
+		if days > math.MaxInt64 {
 			return time.Duration(0)
 		}
 		return time.Hour * 24 * time.Duration(days)


### PR DESCRIPTION
Fixes [https://github.com/dgraph-io/ristretto/security/code-scanning/9](https://github.com/dgraph-io/ristretto/security/code-scanning/9)

To fix the problem, we need to ensure that the parsed value from `strconv.ParseUint` does not exceed the maximum value that can be safely converted to `time.Duration` (which is an alias for `int64`). We can achieve this by adding a bounds check after parsing the value. Specifically, we should check if the parsed value is within the range of `int64` before performing the conversion.

1. Parse the string using `strconv.ParseUint` as before.
2. Add a check to ensure the parsed value does not exceed `math.MaxInt64`.
3. If the value is within bounds, proceed with the conversion to `time.Duration`.
4. If the value exceeds the bounds, return a default value or handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
