### PR TITLE
README: Update example instantiating config types

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ import (
 )
 
 func main() {
-	cache, err := ristretto.NewCache(&ristretto.Config{
+	cache, err := ristretto.NewCache(&ristretto.Config[string,string]{
 		NumCounters: 1e7,     // number of keys to track frequency of (10M).
 		MaxCost:     1 << 30, // maximum cost of cache (1GB).
 		BufferItems: 64,      // number of keys per Get buffer.


### PR DESCRIPTION
The existing example was not up to date with the latest release of the library
```
cannot use generic type "github.com/dgraph-io/ristretto".Config[K z.Key, V any] without instantiation
```

Example working here https://go.dev/play/p/F796kZxNUF0