### PR TITLE
refactor: using defer m.Unlock in store.go

### DIFF
--- a/store.go
+++ b/store.go
@@ -236,5 +236,4 @@ func (m *lockedMap[V]) Clear(onEvict func(item *Item[V])) {
 		}
 	}
 	m.data = make(map[uint64]storeItem[V])
-	m.Unlock()
 }

--- a/store.go
+++ b/store.go
@@ -184,13 +184,12 @@ func (m *lockedMap[V]) Set(i *Item[V]) {
 
 func (m *lockedMap[V]) Del(key, conflict uint64) (uint64, V) {
 	m.Lock()
+	defer m.Unlock()
 	item, ok := m.data[key]
 	if !ok {
-		m.Unlock()
 		return 0, zeroValue[V]()
 	}
 	if conflict != 0 && (conflict != item.conflict) {
-		m.Unlock()
 		return 0, zeroValue[V]()
 	}
 
@@ -199,19 +198,17 @@ func (m *lockedMap[V]) Del(key, conflict uint64) (uint64, V) {
 	}
 
 	delete(m.data, key)
-	m.Unlock()
 	return item.conflict, item.value
 }
 
 func (m *lockedMap[V]) Update(newItem *Item[V]) (V, bool) {
 	m.Lock()
+	defer m.Unlock()
 	item, ok := m.data[newItem.Key]
 	if !ok {
-		m.Unlock()
 		return zeroValue[V](), false
 	}
 	if newItem.Conflict != 0 && (newItem.Conflict != item.conflict) {
-		m.Unlock()
 		return zeroValue[V](), false
 	}
 
@@ -223,12 +220,12 @@ func (m *lockedMap[V]) Update(newItem *Item[V]) (V, bool) {
 		expiration: newItem.Expiration,
 	}
 
-	m.Unlock()
 	return item.value, true
 }
 
 func (m *lockedMap[V]) Clear(onEvict func(item *Item[V])) {
 	m.Lock()
+	defer m.Unlock()
 	i := &Item[V]{}
 	if onEvict != nil {
 		for _, si := range m.data {


### PR DESCRIPTION
- AS-IS: calls m.Unlock() before the end of function(method)
- TO-BE: using `defer` keyword, automatically calling unlock method right before return statements