### PR TITLE
fix memory leak on incor calc of cleanup bucket

### DIFF
--- a/ttl.go
+++ b/ttl.go
@@ -121,9 +121,9 @@ func (m *expirationMap[_]) del(key uint64, expiration time.Time) {
 // cleanup removes all the items in the bucket that was just completed. It deletes
 // those items from the store, and calls the onEvict function on those items.
 // This function is meant to be called periodically.
-func (m *expirationMap[V]) cleanup(store store[V], policy *defaultPolicy[V], onEvict func(item *Item[V])) {
+func (m *expirationMap[V]) cleanup(store store[V], policy *defaultPolicy[V], onEvict func(item *Item[V])) int {
 	if m == nil {
-		return
+		return 0
 	}
 
 	m.Lock()
@@ -164,6 +164,10 @@ func (m *expirationMap[V]) cleanup(store store[V], policy *defaultPolicy[V], onE
 			}
 		}
 	}
+
+	cleanedBucketsCount := len(buckets)
+
+	return cleanedBucketsCount
 }
 
 // clear clears the expirationMap, the caller is responsible for properly

--- a/ttl.go
+++ b/ttl.go
@@ -133,7 +133,10 @@ func (m *expirationMap[V]) cleanup(store store[V], policy *defaultPolicy[V], onE
 	// (but not including) the last one that was cleaned up
 	var buckets []bucket
 	for bucketNum := m.lastCleanedBucketNum + 1; bucketNum <= currentBucketNum; bucketNum++ {
-		buckets = append(buckets, m.buckets[bucketNum])
+		// With an empty bucket, we don't need to add it to the Clean list
+		if b := m.buckets[bucketNum]; b != nil {
+			buckets = append(buckets, b)
+		}
 		delete(m.buckets, bucketNum)
 	}
 	m.lastCleanedBucketNum = currentBucketNum

--- a/ttl_test.go
+++ b/ttl_test.go
@@ -1,0 +1,86 @@
+package ristretto
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestExpirationMapCleanup tests the cleanup functionality of the expiration map.
+// It verifies that expired items are correctly evicted from the store and that
+// non-expired items remain in the store.
+func TestExpirationMapCleanup(t *testing.T) {
+	// Create a new expiration map
+	em := newExpirationMap[int]()
+	// Create a new store
+	s := newShardedMap[int]()
+	// Create a new policy
+	p := newDefaultPolicy[int](100, 10)
+
+	// Add items to the store and expiration map
+	now := time.Now()
+	i1 := &Item[int]{Key: 1, Conflict: 1, Value: 100, Expiration: now.Add(1 * time.Second)}
+	s.Set(i1)
+	em.add(i1.Key, i1.Conflict, i1.Expiration)
+
+	i2 := &Item[int]{Key: 2, Conflict: 2, Value: 200, Expiration: now.Add(3 * time.Second)}
+	s.Set(i2)
+	em.add(i2.Key, i2.Conflict, i2.Expiration)
+
+	// Create a map to store evicted items
+	evictedItems := make(map[uint64]int)
+	evictedItemsOnEvictFunc := func(item *Item[int]) {
+		evictedItems[item.Key] = item.Value
+	}
+
+	// Wait for the first item to expire
+	time.Sleep(2 * time.Second)
+
+	// Cleanup the expiration map
+	em.cleanup(s, p, evictedItemsOnEvictFunc)
+
+	// Check that the first item was evicted
+	require.Equal(t, 1, len(evictedItems), "evictedItems should have 1 item")
+	require.Equal(t, 100, evictedItems[1], "evictedItems should have the first item")
+	_, ok := s.Get(i1.Key, i1.Conflict)
+	require.False(t, ok, "i1 should have been evicted")
+
+	// Check that the second item is still in the store
+	_, ok = s.Get(i2.Key, i2.Conflict)
+	require.True(t, ok, "i2 should still be in the store")
+
+	// Wait for the second item to expire
+	time.Sleep(2 * time.Second)
+
+	// Cleanup the expiration map
+	em.cleanup(s, p, evictedItemsOnEvictFunc)
+
+	// Check that the second item was evicted
+	require.Equal(t, 2, len(evictedItems), "evictedItems should have 2 items")
+	require.Equal(t, 200, evictedItems[2], "evictedItems should have the second item")
+	_, ok = s.Get(i2.Key, i2.Conflict)
+	require.False(t, ok, "i2 should have been evicted")
+
+	t.Run("Miscalculation of buckets does not cause memory leaks", func(t *testing.T) {
+		// Break lastCleanedBucketNum, this can happen if the system time is changed.
+		em.lastCleanedBucketNum = storageBucket(now.AddDate(-1, 0, 0))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		done := make(chan struct{})
+		go func() {
+			em.cleanup(s, p, evictedItemsOnEvictFunc)
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			// cleanup completed!
+		case <-ctx.Done():
+			require.Fail(t, "cleanup method hangs / there may be a memory leak!")
+		}
+	})
+}


### PR DESCRIPTION
cleanup now does not try to clean an empty bucket selected by the cleanup algorithm

this fixes a critical problem of slice growth when the algorithm incorrectly calculates the buckets that need to be cleared, let's say this behavior occurs at the time change described in issue: https://github.com/dgraph-io/ristretto/issues/426

this problem appeared after improving cleanup in this pr: https://github.com/dgraph-io/ristretto/pull/358

most likely the algorithm for calculating the cleaning bins also needs to be revised, but for me now it is important to fix the increase in memory consumption when changing the system time