### PR TITLE
feat: implement iteration over cache elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ adhere to [Semantic Versioning](http://semver.org/spec/v2.0.0.html) starting v1.
 
 - Remove dependency: github.com/pkg/errors (#443)
 - Add public Cache.RemainingCost() method
+- Implement public Cache.Iter() method
+- Make tests concurrent
 
 **Fixed**
 

--- a/policy.go
+++ b/policy.go
@@ -19,11 +19,11 @@ const (
 	lfuSample = 5
 )
 
-func newPolicy[V any](numCounters, maxCost int64) *defaultPolicy[V] {
-	return newDefaultPolicy[V](numCounters, maxCost)
+func newPolicy[K Key, V any](numCounters, maxCost int64) *defaultPolicy[K, V] {
+	return newDefaultPolicy[K, V](numCounters, maxCost)
 }
 
-type defaultPolicy[V any] struct {
+type defaultPolicy[K Key, V any] struct {
 	sync.Mutex
 	admit    *tinyLFU
 	evict    *sampledLFU
@@ -34,8 +34,8 @@ type defaultPolicy[V any] struct {
 	metrics  *Metrics
 }
 
-func newDefaultPolicy[V any](numCounters, maxCost int64) *defaultPolicy[V] {
-	p := &defaultPolicy[V]{
+func newDefaultPolicy[K Key, V any](numCounters, maxCost int64) *defaultPolicy[K, V] {
+	p := &defaultPolicy[K, V]{
 		admit:   newTinyLFU(numCounters),
 		evict:   newSampledLFU(maxCost),
 		itemsCh: make(chan []uint64, 3),
@@ -46,7 +46,7 @@ func newDefaultPolicy[V any](numCounters, maxCost int64) *defaultPolicy[V] {
 	return p
 }
 
-func (p *defaultPolicy[V]) CollectMetrics(metrics *Metrics) {
+func (p *defaultPolicy[K, V]) CollectMetrics(metrics *Metrics) {
 	p.metrics = metrics
 	p.evict.metrics = metrics
 }
@@ -56,7 +56,7 @@ type policyPair struct {
 	cost int64
 }
 
-func (p *defaultPolicy[V]) processItems() {
+func (p *defaultPolicy[K, V]) processItems() {
 	for {
 		select {
 		case items := <-p.itemsCh:
@@ -70,7 +70,7 @@ func (p *defaultPolicy[V]) processItems() {
 	}
 }
 
-func (p *defaultPolicy[V]) Push(keys []uint64) bool {
+func (p *defaultPolicy[K, V]) Push(keys []uint64) bool {
 	if p.isClosed {
 		return false
 	}
@@ -92,7 +92,7 @@ func (p *defaultPolicy[V]) Push(keys []uint64) bool {
 // Add decides whether the item with the given key and cost should be accepted by
 // the policy. It returns the list of victims that have been evicted and a boolean
 // indicating whether the incoming item should be accepted.
-func (p *defaultPolicy[V]) Add(key uint64, cost int64) ([]*Item[V], bool) {
+func (p *defaultPolicy[K, V]) Add(key uint64, cost int64) ([]*Item[K, V], bool) {
 	p.Lock()
 	defer p.Unlock()
 
@@ -126,7 +126,7 @@ func (p *defaultPolicy[V]) Add(key uint64, cost int64) ([]*Item[V], bool) {
 	// O(lg N).
 	sample := make([]*policyPair, 0, lfuSample)
 	// As items are evicted they will be appended to victims.
-	victims := make([]*Item[V], 0)
+	victims := make([]*Item[K, V], 0)
 
 	// Delete victims until there's enough space or a minKey is found that has
 	// more hits than incoming item.
@@ -156,7 +156,7 @@ func (p *defaultPolicy[V]) Add(key uint64, cost int64) ([]*Item[V], bool) {
 		sample[minId] = sample[len(sample)-1]
 		sample = sample[:len(sample)-1]
 		// Store victim in evicted victims slice.
-		victims = append(victims, &Item[V]{
+		victims = append(victims, &Item[K, V]{
 			Key:      minKey,
 			Conflict: 0,
 			Cost:     minCost,
@@ -168,33 +168,33 @@ func (p *defaultPolicy[V]) Add(key uint64, cost int64) ([]*Item[V], bool) {
 	return victims, true
 }
 
-func (p *defaultPolicy[V]) Has(key uint64) bool {
+func (p *defaultPolicy[K, V]) Has(key uint64) bool {
 	p.Lock()
 	_, exists := p.evict.keyCosts[key]
 	p.Unlock()
 	return exists
 }
 
-func (p *defaultPolicy[V]) Del(key uint64) {
+func (p *defaultPolicy[K, V]) Del(key uint64) {
 	p.Lock()
 	p.evict.del(key)
 	p.Unlock()
 }
 
-func (p *defaultPolicy[V]) Cap() int64 {
+func (p *defaultPolicy[K, V]) Cap() int64 {
 	p.Lock()
 	capacity := p.evict.getMaxCost() - p.evict.used
 	p.Unlock()
 	return capacity
 }
 
-func (p *defaultPolicy[V]) Update(key uint64, cost int64) {
+func (p *defaultPolicy[K, V]) Update(key uint64, cost int64) {
 	p.Lock()
 	p.evict.updateIfHas(key, cost)
 	p.Unlock()
 }
 
-func (p *defaultPolicy[V]) Cost(key uint64) int64 {
+func (p *defaultPolicy[K, V]) Cost(key uint64) int64 {
 	p.Lock()
 	if cost, found := p.evict.keyCosts[key]; found {
 		p.Unlock()
@@ -204,14 +204,14 @@ func (p *defaultPolicy[V]) Cost(key uint64) int64 {
 	return -1
 }
 
-func (p *defaultPolicy[V]) Clear() {
+func (p *defaultPolicy[K, V]) Clear() {
 	p.Lock()
 	p.admit.clear()
 	p.evict.clear()
 	p.Unlock()
 }
 
-func (p *defaultPolicy[V]) Close() {
+func (p *defaultPolicy[K, V]) Close() {
 	if p.isClosed {
 		return
 	}
@@ -225,14 +225,14 @@ func (p *defaultPolicy[V]) Close() {
 	p.isClosed = true
 }
 
-func (p *defaultPolicy[V]) MaxCost() int64 {
+func (p *defaultPolicy[K, V]) MaxCost() int64 {
 	if p == nil || p.evict == nil {
 		return 0
 	}
 	return p.evict.getMaxCost()
 }
 
-func (p *defaultPolicy[V]) UpdateMaxCost(maxCost int64) {
+func (p *defaultPolicy[K, V]) UpdateMaxCost(maxCost int64) {
 	if p == nil || p.evict == nil {
 		return
 	}

--- a/policy_test.go
+++ b/policy_test.go
@@ -13,21 +13,27 @@ import (
 )
 
 func TestPolicy(t *testing.T) {
+	t.Parallel()
+
 	defer func() {
 		require.Nil(t, recover())
 	}()
-	newPolicy[int](100, 10)
+	newPolicy[int, int](100, 10)
 }
 
 func TestPolicyMetrics(t *testing.T) {
-	p := newDefaultPolicy[int](100, 10)
+	t.Parallel()
+
+	p := newDefaultPolicy[int, int](100, 10)
 	p.CollectMetrics(newMetrics())
 	require.NotNil(t, p.metrics)
 	require.NotNil(t, p.evict.metrics)
 }
 
 func TestPolicyProcessItems(t *testing.T) {
-	p := newDefaultPolicy[int](100, 10)
+	t.Parallel()
+
+	p := newDefaultPolicy[int, int](100, 10)
 	p.itemsCh <- []uint64{1, 2, 2}
 	time.Sleep(wait)
 	p.Lock()
@@ -45,7 +51,9 @@ func TestPolicyProcessItems(t *testing.T) {
 }
 
 func TestPolicyPush(t *testing.T) {
-	p := newDefaultPolicy[int](100, 10)
+	t.Parallel()
+
+	p := newDefaultPolicy[int, int](100, 10)
 	require.True(t, p.Push([]uint64{}))
 
 	keepCount := 0
@@ -58,7 +66,9 @@ func TestPolicyPush(t *testing.T) {
 }
 
 func TestPolicyAdd(t *testing.T) {
-	p := newDefaultPolicy[int](1000, 100)
+	t.Parallel()
+
+	p := newDefaultPolicy[int, int](1000, 100)
 	if victims, added := p.Add(1, 101); victims != nil || added {
 		t.Fatal("can't add an item bigger than entire cache")
 	}
@@ -87,14 +97,18 @@ func TestPolicyAdd(t *testing.T) {
 }
 
 func TestPolicyHas(t *testing.T) {
-	p := newDefaultPolicy[int](100, 10)
+	t.Parallel()
+
+	p := newDefaultPolicy[int, int](100, 10)
 	p.Add(1, 1)
 	require.True(t, p.Has(1))
 	require.False(t, p.Has(2))
 }
 
 func TestPolicyDel(t *testing.T) {
-	p := newDefaultPolicy[int](100, 10)
+	t.Parallel()
+
+	p := newDefaultPolicy[int, int](100, 10)
 	p.Add(1, 1)
 	p.Del(1)
 	p.Del(2)
@@ -103,13 +117,17 @@ func TestPolicyDel(t *testing.T) {
 }
 
 func TestPolicyCap(t *testing.T) {
-	p := newDefaultPolicy[int](100, 10)
+	t.Parallel()
+
+	p := newDefaultPolicy[int, int](100, 10)
 	p.Add(1, 1)
 	require.Equal(t, int64(9), p.Cap())
 }
 
 func TestPolicyUpdate(t *testing.T) {
-	p := newDefaultPolicy[int](100, 10)
+	t.Parallel()
+
+	p := newDefaultPolicy[int, int](100, 10)
 	p.Add(1, 1)
 	p.Update(1, 2)
 	p.Lock()
@@ -118,14 +136,18 @@ func TestPolicyUpdate(t *testing.T) {
 }
 
 func TestPolicyCost(t *testing.T) {
-	p := newDefaultPolicy[int](100, 10)
+	t.Parallel()
+
+	p := newDefaultPolicy[int, int](100, 10)
 	p.Add(1, 2)
 	require.Equal(t, int64(2), p.Cost(1))
 	require.Equal(t, int64(-1), p.Cost(2))
 }
 
 func TestPolicyClear(t *testing.T) {
-	p := newDefaultPolicy[int](100, 10)
+	t.Parallel()
+
+	p := newDefaultPolicy[int, int](100, 10)
 	p.Add(1, 1)
 	p.Add(2, 2)
 	p.Add(3, 3)
@@ -137,29 +159,37 @@ func TestPolicyClear(t *testing.T) {
 }
 
 func TestPolicyClose(t *testing.T) {
+	t.Parallel()
+
 	defer func() {
 		require.NotNil(t, recover())
 	}()
 
-	p := newDefaultPolicy[int](100, 10)
+	p := newDefaultPolicy[int, int](100, 10)
 	p.Add(1, 1)
 	p.Close()
 	p.itemsCh <- []uint64{1}
 }
 
 func TestPushAfterClose(t *testing.T) {
-	p := newDefaultPolicy[int](100, 10)
+	t.Parallel()
+
+	p := newDefaultPolicy[int, int](100, 10)
 	p.Close()
 	require.False(t, p.Push([]uint64{1, 2}))
 }
 
 func TestAddAfterClose(t *testing.T) {
-	p := newDefaultPolicy[int](100, 10)
+	t.Parallel()
+
+	p := newDefaultPolicy[int, int](100, 10)
 	p.Close()
 	p.Add(1, 1)
 }
 
 func TestSampledLFUAdd(t *testing.T) {
+	t.Parallel()
+
 	e := newSampledLFU(4)
 	e.add(1, 1)
 	e.add(2, 2)
@@ -169,6 +199,8 @@ func TestSampledLFUAdd(t *testing.T) {
 }
 
 func TestSampledLFUDel(t *testing.T) {
+	t.Parallel()
+
 	e := newSampledLFU(4)
 	e.add(1, 1)
 	e.add(2, 2)
@@ -180,6 +212,8 @@ func TestSampledLFUDel(t *testing.T) {
 }
 
 func TestSampledLFUUpdate(t *testing.T) {
+	t.Parallel()
+
 	e := newSampledLFU(4)
 	e.add(1, 1)
 	require.True(t, e.updateIfHas(1, 2))
@@ -188,6 +222,8 @@ func TestSampledLFUUpdate(t *testing.T) {
 }
 
 func TestSampledLFUClear(t *testing.T) {
+	t.Parallel()
+
 	e := newSampledLFU(4)
 	e.add(1, 1)
 	e.add(2, 2)
@@ -198,6 +234,8 @@ func TestSampledLFUClear(t *testing.T) {
 }
 
 func TestSampledLFURoom(t *testing.T) {
+	t.Parallel()
+
 	e := newSampledLFU(16)
 	e.add(1, 1)
 	e.add(2, 2)
@@ -206,6 +244,8 @@ func TestSampledLFURoom(t *testing.T) {
 }
 
 func TestSampledLFUSample(t *testing.T) {
+	t.Parallel()
+
 	e := newSampledLFU(16)
 	e.add(4, 4)
 	e.add(5, 5)
@@ -226,6 +266,8 @@ func TestSampledLFUSample(t *testing.T) {
 }
 
 func TestTinyLFUIncrement(t *testing.T) {
+	t.Parallel()
+
 	a := newTinyLFU(4)
 	a.Increment(1)
 	a.Increment(1)
@@ -239,6 +281,8 @@ func TestTinyLFUIncrement(t *testing.T) {
 }
 
 func TestTinyLFUEstimate(t *testing.T) {
+	t.Parallel()
+
 	a := newTinyLFU(8)
 	a.Increment(1)
 	a.Increment(1)
@@ -248,6 +292,8 @@ func TestTinyLFUEstimate(t *testing.T) {
 }
 
 func TestTinyLFUPush(t *testing.T) {
+	t.Parallel()
+
 	a := newTinyLFU(16)
 	a.Push([]uint64{1, 2, 2, 3, 3, 3})
 	require.Equal(t, int64(1), a.Estimate(1))
@@ -257,6 +303,8 @@ func TestTinyLFUPush(t *testing.T) {
 }
 
 func TestTinyLFUClear(t *testing.T) {
+	t.Parallel()
+
 	a := newTinyLFU(16)
 	a.Push([]uint64{1, 3, 3, 3})
 	a.clear()

--- a/ring_test.go
+++ b/ring_test.go
@@ -26,6 +26,8 @@ func (c *testConsumer) Push(items []uint64) bool {
 }
 
 func TestRingDrain(t *testing.T) {
+	t.Parallel()
+
 	drains := 0
 	r := newRingBuffer(&testConsumer{
 		push: func(items []uint64) {
@@ -40,6 +42,8 @@ func TestRingDrain(t *testing.T) {
 }
 
 func TestRingReset(t *testing.T) {
+	t.Parallel()
+
 	drains := 0
 	r := newRingBuffer(&testConsumer{
 		push: func(items []uint64) {
@@ -54,6 +58,8 @@ func TestRingReset(t *testing.T) {
 }
 
 func TestRingConsumer(t *testing.T) {
+	t.Parallel()
+
 	mu := &sync.Mutex{}
 	drainItems := make(map[uint64]struct{})
 	r := newRingBuffer(&testConsumer{

--- a/sketch_test.go
+++ b/sketch_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestSketch(t *testing.T) {
+	t.Parallel()
+
 	defer func() {
 		require.NotNil(t, recover())
 	}()
@@ -22,6 +24,8 @@ func TestSketch(t *testing.T) {
 }
 
 func TestSketchIncrement(t *testing.T) {
+	t.Parallel()
+
 	s := newCmSketch(16)
 	s.Increment(1)
 	s.Increment(5)
@@ -35,6 +39,8 @@ func TestSketchIncrement(t *testing.T) {
 }
 
 func TestSketchEstimate(t *testing.T) {
+	t.Parallel()
+
 	s := newCmSketch(16)
 	s.Increment(1)
 	s.Increment(1)
@@ -43,6 +49,8 @@ func TestSketchEstimate(t *testing.T) {
 }
 
 func TestSketchReset(t *testing.T) {
+	t.Parallel()
+
 	s := newCmSketch(16)
 	s.Increment(1)
 	s.Increment(1)
@@ -53,6 +61,8 @@ func TestSketchReset(t *testing.T) {
 }
 
 func TestSketchClear(t *testing.T) {
+	t.Parallel()
+
 	s := newCmSketch(16)
 	for i := 0; i < 16; i++ {
 		s.Increment(uint64(i))
@@ -64,6 +74,8 @@ func TestSketchClear(t *testing.T) {
 }
 
 func TestNext2Power(t *testing.T) {
+	t.Parallel()
+
 	sz := 12 << 30
 	szf := float64(sz) * 0.01
 	val := int64(szf)

--- a/stress_test.go
+++ b/stress_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestStressSetGet(t *testing.T) {
+	t.Parallel()
+
 	c, err := NewCache(&Config[int, int]{
 		NumCounters:        1000,
 		MaxCost:            100,
@@ -56,6 +58,8 @@ func TestStressSetGet(t *testing.T) {
 }
 
 func TestStressHitRatio(t *testing.T) {
+	t.Parallel()
+
 	key := sim.NewZipfian(1.0001, 1, 1000)
 	c, err := NewCache(&Config[uint64, uint64]{
 		NumCounters: 1000,

--- a/ttl_test.go
+++ b/ttl_test.go
@@ -16,26 +16,28 @@ import (
 // It verifies that expired items are correctly evicted from the store and that
 // non-expired items remain in the store.
 func TestExpirationMapCleanup(t *testing.T) {
+	t.Parallel()
+
 	// Create a new expiration map
-	em := newExpirationMap[int]()
+	em := newExpirationMap[int, int]()
 	// Create a new store
-	s := newShardedMap[int]()
+	s := newShardedMap[int, int]()
 	// Create a new policy
-	p := newDefaultPolicy[int](100, 10)
+	p := newDefaultPolicy[int, int](100, 10)
 
 	// Add items to the store and expiration map
 	now := time.Now()
-	i1 := &Item[int]{Key: 1, Conflict: 1, Value: 100, Expiration: now.Add(1 * time.Second)}
+	i1 := &Item[int, int]{Key: 1, Conflict: 1, Value: 100, Expiration: now.Add(1 * time.Second)}
 	s.Set(i1)
 	em.add(i1.Key, i1.Conflict, i1.Expiration)
 
-	i2 := &Item[int]{Key: 2, Conflict: 2, Value: 200, Expiration: now.Add(3 * time.Second)}
+	i2 := &Item[int, int]{Key: 2, Conflict: 2, Value: 200, Expiration: now.Add(3 * time.Second)}
 	s.Set(i2)
 	em.add(i2.Key, i2.Conflict, i2.Expiration)
 
 	// Create a map to store evicted items
 	evictedItems := make(map[uint64]int)
-	evictedItemsOnEvictFunc := func(item *Item[int]) {
+	evictedItemsOnEvictFunc := func(item *Item[int, int]) {
 		evictedItems[item.Key] = item.Value
 	}
 


### PR DESCRIPTION

**Description**

Often, ***Ristretto*** is used not only as a cache before databases, but also as a complete in-memory storage. And there are cases when you need to do something with all the elements in the cache (for example, completely unload them and send them somewhere). However, in the current implementation, this is impossible. For this, the [Iter](https://github.com/hypermodeinc/ristretto/pull/460/files#diff-ed648181f98484bd12541509e0ae7b5ad1d1de7674ab1721814b47ddd5c95de4R87)  function was implemented, which goes through all the cache elements and calls a callback function for each one of them.

P.S. In addition, when running the tests, it was noticed that they were running for quite a long time, so they were parallelized, which significantly accelerated their work.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable
