### PR TITLE
build: Remove LDFLAGS assignment

### DIFF
--- a/z/calloc_jemalloc.go
+++ b/z/calloc_jemalloc.go
@@ -8,7 +8,6 @@
 package z
 
 /*
-#cgo LDFLAGS: /usr/local/lib/libjemalloc.a -L/usr/local/lib -Wl,-rpath,/usr/local/lib -ljemalloc -lm -lstdc++ -pthread -ldl
 #include <stdlib.h>
 #include <jemalloc/jemalloc.h>
 */


### PR DESCRIPTION
**Description**

Setting LDFLAGS here forces users building software that depends on ristretto to have jemalloc installed in /usr/local/lib.  Requiring the builder to set LDFLAGS allows for more flexible configurations where jemalloc might be installed elsewhere.

This change also requires updates to the dgraph and badger repos.  See PRs in those repos for details.

https://github.com/hypermodeinc/badger/pull/2230
https://github.com/hypermodeinc/dgraph/pull/9510

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [ ] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR
- [ ] Tests added for new functionality, or regression tests for bug fixes added as applicable
