### PR TITLE
feat: support updating expiration time by cache key

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -367,6 +367,16 @@ func (c *Cache[K, V]) SetWithTTL(key K, value V, cost int64, ttl time.Duration) 
 	}
 }
 
+// ExpireAt updates the expiration time for the specified key.
+// It returns true if the item was found and the expiration was updated, and false if the item was not found or the cache is closed.
+func (c *Cache[K, V]) ExpireAt(key K, expiration time.Time) bool {
+	if c == nil || c.isClosed.Load() {
+		return false
+	}
+	keyHash, _ := c.keyToHash(key)
+	return c.storedItems.ExpireAt(keyHash, expiration)
+}
+
 // Del deletes the key-value item from the cache if it exists.
 func (c *Cache[K, V]) Del(key K) {
 	if c == nil || c.isClosed.Load() {

--- a/store.go
+++ b/store.go
@@ -31,6 +31,9 @@ type store[V any] interface {
 	Get(uint64, uint64) (V, bool)
 	// Expiration returns the expiration time for this key.
 	Expiration(uint64) time.Time
+	// ExpireAt updates the expiration time for this key.
+	// ExpireAt returns true if the expiration was updated successfully, and false if the key was not found.
+	ExpireAt(uint64, time.Time) bool
 	// Set adds the key-value pair to the Map or updates the value if it's
 	// already present. The key-value pair is passed as a pointer to an
 	// item object.
@@ -114,6 +117,10 @@ func (sm *shardedMap[V]) Expiration(key uint64) time.Time {
 	return sm.shards[key%numShards].Expiration(key)
 }
 
+func (sm *shardedMap[V]) ExpireAt(key uint64, expiration time.Time) bool {
+	return sm.shards[key%numShards].ExpireAt(key, expiration)
+}
+
 func (sm *shardedMap[V]) Set(i *Item[V]) {
 	if i == nil {
 		// If item is nil make this Set a no-op.
@@ -185,6 +192,19 @@ func (m *lockedMap[V]) Expiration(key uint64) time.Time {
 	m.RLock()
 	defer m.RUnlock()
 	return m.data[key].expiration
+}
+
+func (m *lockedMap[V]) ExpireAt(key uint64, expiration time.Time) bool {
+	m.Lock()
+	defer m.Unlock()
+	item, ok := m.data[key]
+	if !ok {
+		return false
+	}
+	m.em.update(key, item.conflict, item.expiration, expiration)
+	item.expiration = expiration
+	m.data[key] = item
+	return true
 }
 
 func (m *lockedMap[V]) Set(i *Item[V]) {

--- a/store_test.go
+++ b/store_test.go
@@ -332,6 +332,26 @@ func TestStoreExpiration(t *testing.T) {
 	require.True(t, ttl.IsZero())
 }
 
+func TestStoreExpireAt(t *testing.T) {
+	s := newStore[int]()
+	key, conflict := z.KeyToHash(1)
+	expiration := time.Now().Add(time.Second)
+	i := Item[int]{
+		Key:        key,
+		Conflict:   conflict,
+		Expiration: expiration,
+	}
+	s.Set(&i)
+	ttl := s.Expiration(key)
+	require.Equal(t, expiration, ttl)
+
+	newExpiry := time.Now().Add(2 * time.Second)
+	ok := s.ExpireAt(key, newExpiry)
+	require.True(t, ok)
+	ttl = s.Expiration(key)
+	require.WithinDuration(t, newExpiry, ttl, 100*time.Millisecond)
+}
+
 func BenchmarkStoreGet(b *testing.B) {
 	s := newStore[int]()
 	key, conflict := z.KeyToHash(1)


### PR DESCRIPTION
**Description**

Adds a new `ExpireAt` function to the cache & underlying layers that allows an existing cache item's expiry time to be updated, without needing to write a new entry

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable