### PR TITLE
fix: release lock early in Clear() to prevent lock starvation during eviction

### DIFF
--- a/store.go
+++ b/store.go
@@ -267,15 +267,17 @@ func (m *lockedMap[V]) Update(newItem *Item[V]) (V, bool) {
 
 func (m *lockedMap[V]) Clear(onEvict func(item *Item[V])) {
 	m.Lock()
-	defer m.Unlock()
-	i := &Item[V]{}
+	dataToEvict := m.data
+	m.data = make(map[uint64]storeItem[V])
+	m.Unlock()
+
 	if onEvict != nil {
-		for _, si := range m.data {
+		i := &Item[V]{}
+		for _, si := range dataToEvict {
 			i.Key = si.key
 			i.Conflict = si.conflict
 			i.Value = si.value
 			onEvict(i)
 		}
 	}
-	m.data = make(map[uint64]storeItem[V])
 }

--- a/store_test.go
+++ b/store_test.go
@@ -332,6 +332,47 @@ func TestStoreExpiration(t *testing.T) {
 	require.True(t, ttl.IsZero())
 }
 
+func TestStoreClearConcurrent(t *testing.T) {
+	s := newShardedMap[int]()
+	
+	for i := 0; i < 100; i++ {
+		s.Set(&Item[int]{
+			Key:      uint64(i * 256),
+			Conflict: 0,
+			Value:    i,
+		})
+	}
+
+	evictStarted := make(chan struct{})
+	evictFinished := make(chan struct{})
+
+	go func() {
+		s.Clear(func(item *Item[int]) {
+			select {
+			case evictStarted <- struct{}{}:
+			default:
+			}
+			time.Sleep(2 * time.Millisecond)
+		})
+		close(evictFinished)
+	}()
+
+	<-evictStarted
+
+	getFinished := make(chan struct{})
+	go func() {
+		s.Get(0, 0)
+		close(getFinished)
+	}()
+
+	select {
+	case <-getFinished:
+		// success: Get completed concurrently while Clear is executing onEvict
+	case <-evictFinished:
+		t.Fatal("Get blocked by Clear: lock starvation during eviction")
+	}
+}
+
 func BenchmarkStoreGet(b *testing.B) {
 	s := newStore[int]()
 	key, conflict := z.KeyToHash(1)


### PR DESCRIPTION
**Description**

This PR addresses a lock starvation issue in [store]'s [Clear()] method. 

Currently, `lockedMap.Clear()` holds the shard's write-lock for the entire duration of the `onEvict` callback loop. Depending on the operations performed inside `onEvict`, this can block incoming [Get]/[Set]/[Del] requests to that shard, potentially causing delays for the application.

Changes:
- Extracted the map replacement logic inside `lockedMap.Clear()`.
- Replaced `defer m.Unlock()` with an early `m.Unlock()` right after swapping the internal map to a new empty map.
- The `onEvict` callbacks are now safely executed outside the critical section, preventing stalls.
- Added a concurrency test [TestStoreClearConcurrent] to the test suite.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable
