### PR TITLE
perf: pre-allocate keyCosts map in sampledLFU

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -37,7 +37,7 @@ type defaultPolicy[V any] struct {
 func newDefaultPolicy[V any](numCounters, maxCost int64) *defaultPolicy[V] {
 	p := &defaultPolicy[V]{
 		admit:   newTinyLFU(numCounters),
-		evict:   newSampledLFU(maxCost),
+		evict:   newSampledLFU(maxCost, numCounters),
 		itemsCh: make(chan []uint64, 3),
 		stop:    make(chan struct{}),
 		done:    make(chan struct{}),
@@ -253,9 +253,11 @@ type sampledLFU struct {
 	keyCosts map[uint64]int64
 }
 
-func newSampledLFU(maxCost int64) *sampledLFU {
+func newSampledLFU(maxCost, numCounters int64) *sampledLFU {
 	return &sampledLFU{
-		keyCosts: make(map[uint64]int64),
+		// Pre-allocate keyCosts assuming the recommended 10:1 counter-to-item ratio
+		// to minimize map resizing.
+		keyCosts: make(map[uint64]int64, numCounters/10),
 		maxCost:  maxCost,
 	}
 }

--- a/policy.go
+++ b/policy.go
@@ -37,7 +37,7 @@ type defaultPolicy[V any] struct {
 func newDefaultPolicy[V any](numCounters, maxCost int64) *defaultPolicy[V] {
 	p := &defaultPolicy[V]{
 		admit:   newTinyLFU(numCounters),
-		evict:   newSampledLFU(maxCost),
+		evict:   newSampledLFU(maxCost, numCounters),
 		itemsCh: make(chan []uint64, 3),
 		stop:    make(chan struct{}),
 		done:    make(chan struct{}),
@@ -249,14 +249,19 @@ type sampledLFU struct {
 	// or slice can be relied upon to be 64-bit aligned."
 	maxCost  int64
 	used     int64
+	keyCap   int64
 	metrics  *Metrics
 	keyCosts map[uint64]int64
 }
 
-func newSampledLFU(maxCost int64) *sampledLFU {
+func newSampledLFU(maxCost, numCounters int64) *sampledLFU {
+	// Pre-allocate keyCosts assuming the recommended 10:1 counter-to-item ratio
+	// to minimize map resizing.
+	capacity := numCounters / 10
 	return &sampledLFU{
-		keyCosts: make(map[uint64]int64),
+		keyCosts: make(map[uint64]int64, capacity),
 		maxCost:  maxCost,
+		keyCap:   capacity,
 	}
 }
 
@@ -322,7 +327,7 @@ func (p *sampledLFU) updateIfHas(key uint64, cost int64) bool {
 
 func (p *sampledLFU) clear() {
 	p.used = 0
-	p.keyCosts = make(map[uint64]int64)
+	p.keyCosts = make(map[uint64]int64, p.keyCap)
 }
 
 // tinyLFU is an admission helper that keeps track of access frequency using

--- a/policy_test.go
+++ b/policy_test.go
@@ -160,7 +160,7 @@ func TestAddAfterClose(t *testing.T) {
 }
 
 func TestSampledLFUAdd(t *testing.T) {
-	e := newSampledLFU(4)
+	e := newSampledLFU(4, 100)
 	e.add(1, 1)
 	e.add(2, 2)
 	e.add(3, 1)
@@ -169,7 +169,7 @@ func TestSampledLFUAdd(t *testing.T) {
 }
 
 func TestSampledLFUDel(t *testing.T) {
-	e := newSampledLFU(4)
+	e := newSampledLFU(4, 100)
 	e.add(1, 1)
 	e.add(2, 2)
 	e.del(2)
@@ -180,7 +180,7 @@ func TestSampledLFUDel(t *testing.T) {
 }
 
 func TestSampledLFUUpdate(t *testing.T) {
-	e := newSampledLFU(4)
+	e := newSampledLFU(4, 100)
 	e.add(1, 1)
 	require.True(t, e.updateIfHas(1, 2))
 	require.Equal(t, int64(2), e.used)
@@ -188,7 +188,7 @@ func TestSampledLFUUpdate(t *testing.T) {
 }
 
 func TestSampledLFUClear(t *testing.T) {
-	e := newSampledLFU(4)
+	e := newSampledLFU(4, 100)
 	e.add(1, 1)
 	e.add(2, 2)
 	e.add(3, 1)
@@ -198,7 +198,7 @@ func TestSampledLFUClear(t *testing.T) {
 }
 
 func TestSampledLFURoom(t *testing.T) {
-	e := newSampledLFU(16)
+	e := newSampledLFU(16, 1000)
 	e.add(1, 1)
 	e.add(2, 2)
 	e.add(3, 3)
@@ -206,7 +206,7 @@ func TestSampledLFURoom(t *testing.T) {
 }
 
 func TestSampledLFUSample(t *testing.T) {
-	e := newSampledLFU(16)
+	e := newSampledLFU(16, 1000)
 	e.add(4, 4)
 	e.add(5, 5)
 	sample := e.fillSample([]*policyPair{
@@ -262,4 +262,50 @@ func TestTinyLFUClear(t *testing.T) {
 	a.clear()
 	require.Equal(t, int64(0), a.incrs)
 	require.Equal(t, int64(0), a.Estimate(3))
+}
+
+func BenchmarkSampledLFUPopulate(b *testing.B) {
+	sizes := []struct {
+		name string
+		n    int
+	}{
+		{"1K", 1000},
+		{"10K", 10000},
+		{"100K", 100000},
+		{"1M", 1000000},
+	}
+	for _, s := range sizes {
+		b.Run(s.name, func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				e := newSampledLFU(int64(s.n*100), int64(s.n*10))
+				for i := 0; i < s.n; i++ {
+					e.add(uint64(i), 1)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkSampledLFUFillSample(b *testing.B) {
+	sizes := []struct {
+		name string
+		n    int
+	}{
+		{"100", 100},
+		{"1K", 1000},
+		{"10K", 10000},
+		{"100K", 100000},
+	}
+	for _, s := range sizes {
+		b.Run(s.name, func(b *testing.B) {
+			e := newSampledLFU(int64(s.n*100), int64(s.n*10))
+			for i := 0; i < s.n; i++ {
+				e.add(uint64(i), 1)
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				e.fillSample(make([]*policyPair, 0, lfuSample))
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- Pre-allocate `keyCosts` map in `newSampledLFU()` using `numCounters/10` as capacity hint
- `NumCounters` is recommended to be 10x the expected max items (per README usage example), so dividing by 10 gives a reasonable estimate of actual item count
- Eliminates repeated map resizing and rehashing during cache warm-up

## Changes
- **policy.go**: `newSampledLFU` accepts `numCounters` parameter, pre-allocates map with estimated item count
- **policy_test.go**: Updated test calls to match new signature. Added `BenchmarkSampledLFUPopulate` and `BenchmarkSampledLFUFillSample`.

## Benchmark
```
goos: darwin
goarch: arm64
cpu: Apple M1

name                        old ns/op       new ns/op       delta
Populate/1K                 40,286          10,262          -74.5%
Populate/10K                344,363         109,292         -68.3%
Populate/100K               3,363,953       1,253,737       -62.7%
Populate/1M                 57,521,353      38,417,256      -33.2%

name                        old B/op        new B/op        delta
Populate/1K                 74,264          36,944          -50.3%
Populate/10K                591,484         295,553         -50.0%
Populate/100K               4,729,388       2,364,561       -50.0%
Populate/1M                 75,615,756      37,832,735      -50.0%

name                        old allocs/op   new allocs/op   delta
Populate/1K                 20              5               -75.0%
Populate/10K                79              33              -58.2%
Populate/100K               530             257             -51.5%
Populate/1M                 8,209           4,097           -50.1%
```

## Checklist
- [x] Code compiles correctly and linting passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable