### PR TITLE
docs: add contributing guide and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,113 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a
+harassment-free experience for everyone, regardless of age, body size, visible or invisible
+disability, ethnicity, sex characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and
+healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the
+  experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their
+  explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior
+and will take appropriate and fair corrective action in response to any behavior that they deem
+inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits,
+code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and
+will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is
+officially representing the community in public spaces. Examples of representing our community
+include using an official e-mail address, posting via an official social media account, or acting as
+an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community
+leaders responsible for enforcement at dgraph-admin@istaridigital.com. All complaints will be
+reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any
+incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for
+any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or
+unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the
+nature of the violation and an explanation of why the behavior was inappropriate. A public apology
+may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people
+involved, including unsolicited interaction with those enforcing the Code of Conduct, for a
+specified period of time. This includes avoiding interactions in community spaces as well as
+external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate
+behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the
+community for a specified period of time. No public or private interaction with the people involved,
+including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this
+period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including
+sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement
+of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,129 @@
+# Contribution Guide
+
+- [Contribution Guide](#contribution-guide)
+  - [Before you get started](#before-you-get-started)
+    - [Code of Conduct](#code-of-conduct)
+  - [Your First Contribution](#your-first-contribution)
+    - [Code style](#code-style)
+    - [License Header](#license-header)
+    - [Find a good first topic](#find-a-good-first-topic)
+  - [Setting up your development environment](#setting-up-your-development-environment)
+    - [Fork the project](#fork-the-project)
+    - [Clone the project](#clone-the-project)
+    - [New branch for a new code](#new-branch-for-a-new-code)
+    - [Test](#test)
+    - [Commit and push](#commit-and-push)
+    - [Create a Pull Request](#create-a-pull-request)
+    - [Get a code review](#get-a-code-review)
+
+## Before you get started
+
+### Code of Conduct
+
+Please make sure to read and observe our [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Your First Contribution
+
+### Code style
+
+- We follow [Go Code Review](https://github.com/golang/go/wiki/CodeReviewComments)
+- At a minimum, use `go fmt` to format your code before committing. Ideally you should use `trunk`
+  as our CI will run `trunk` on your code
+- If you see _any code_ which clearly violates the style guide, please fix it and send a pull
+  request. No need to ask for permission
+- Avoid unnecessary vertical spaces. Use your judgment or follow the code review comments
+- Wrap your code and comments to 120 characters, unless doing so makes the code less legible
+
+### License Header
+
+Every new source file must begin with a license header. Ristretto is licensed under the Apache 2.0
+license:
+
+```sh
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+```
+
+### Find a good first topic
+
+You can start by finding an existing issue with the
+[good first issue](https://github.com/dgraph-io/ristretto/labels/good%20first%20issue) or
+[help wanted](https://github.com/dgraph-io/ristretto/labels/help%20wanted) labels. These issues are
+well suited for new contributors.
+
+## Setting up your development environment
+
+- [Install Go 1.24.0 or above](https://golang.org/doc/install). Go 1.25.0 or above is recommended.
+- Install
+  [trunk](https://docs.trunk.io/code-quality/overview/getting-started/install#install-the-launcher).
+  Our CI uses trunk to lint and check code, having it installed locally will save you time.
+
+### Fork the project
+
+- Visit https://github.com/dgraph-io/ristretto
+- Click the `Fork` button (top right) to create a fork of the repository
+
+### Clone the project
+
+```sh
+git clone https://github.com/$GITHUB_USER/ristretto
+cd ristretto
+git remote add upstream git@github.com:dgraph-io/ristretto.git
+
+# Never push to the upstream main
+git remote set-url --push upstream no_push
+```
+
+### New branch for a new code
+
+Get your local main up to date:
+
+```sh
+git fetch upstream
+git checkout main
+git rebase upstream/main
+```
+
+Create a new branch from the main:
+
+```sh
+git checkout -b my_new_feature
+```
+
+And now you can finally add your changes to project.
+
+### Test
+
+Build and run all tests:
+
+```sh
+go test -timeout=20m -race -covermode atomic -coverprofile=covprofile ./...
+```
+
+### Commit and push
+
+Commit your changes:
+
+```sh
+git commit
+```
+
+When the changes are ready to review:
+
+```sh
+git push origin my_new_feature
+```
+
+### Create a Pull Request
+
+Just open `https://github.com/$GITHUB_USER/ristretto/pull/new/my_new_feature` and fill the PR
+description.
+
+### Get a code review
+
+If your pull request (PR) is opened, it will be assigned to one or more reviewers. Those reviewers
+will do a code review.
+
+To address review comments, you should commit the changes to the same branch of the PR on your fork.


### PR DESCRIPTION
Add CONTRIBUTING.md and CODE_OF_CONDUCT.md to the repository.

- CONTRIBUTING.md provides guidance for contributors, including code style, testing, and PR workflow
- CODE_OF_CONDUCT.md establishes community standards for all contributors

The CONTRIBUTING.md has been adapted from a template to be specific to Ristretto, with references to Go 1.24.0+, the correct test command, and updated repository URLs.