### PR TITLE
perf: split admission and eviction locks

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -24,7 +24,8 @@ func newPolicy[V any](numCounters, maxCost int64) *defaultPolicy[V] {
 }
 
 type defaultPolicy[V any] struct {
-	sync.Mutex
+	admitMu  sync.Mutex
+	evictMu  sync.RWMutex
 	admit    *tinyLFU
 	evict    *sampledLFU
 	itemsCh  chan []uint64
@@ -60,9 +61,9 @@ func (p *defaultPolicy[V]) processItems() {
 	for {
 		select {
 		case items := <-p.itemsCh:
-			p.Lock()
+			p.admitMu.Lock()
 			p.admit.Push(items)
-			p.Unlock()
+			p.admitMu.Unlock()
 		case <-p.stop:
 			p.done <- struct{}{}
 			return
@@ -93,122 +94,144 @@ func (p *defaultPolicy[V]) Push(keys []uint64) bool {
 // the policy. It returns the list of victims that have been evicted and a boolean
 // indicating whether the incoming item should be accepted.
 func (p *defaultPolicy[V]) Add(key uint64, cost int64) ([]*Item[V], bool) {
-	p.Lock()
-	defer p.Unlock()
-
 	// Cannot add an item bigger than entire cache.
 	if cost > p.evict.getMaxCost() {
 		return nil, false
 	}
 
-	// No need to go any further if the item is already in the cache.
-	if has := p.evict.updateIfHas(key, cost); has {
-		// An update does not count as an addition, so return false.
-		return nil, false
-	}
+	var victims []*Item[V]
+	incHits, hasIncHits := int64(0), false
 
-	// If the execution reaches this point, the key doesn't exist in the cache.
-	// Calculate the remaining room in the cache (usually bytes).
-	room := p.evict.roomLeft(cost)
-	if room >= 0 {
-		// There's enough room in the cache to store the new item without
-		// overflowing. Do that now and stop here.
-		p.evict.add(key, cost)
-		p.metrics.add(costAdd, key, uint64(cost))
-		return nil, true
-	}
-
-	// incHits is the hit count for the incoming item.
-	incHits := p.admit.Estimate(key)
-	// sample is the eviction candidate pool to be filled via random sampling.
-	// TODO: perhaps we should use a min heap here. Right now our time
-	// complexity is N for finding the min. Min heap should bring it down to
-	// O(lg N).
-	sample := make([]*policyPair, 0, lfuSample)
-	// As items are evicted they will be appended to victims.
-	victims := make([]*Item[V], 0)
-
-	// Delete victims until there's enough space or a minKey is found that has
-	// more hits than incoming item.
-	for ; room < 0; room = p.evict.roomLeft(cost) {
-		// Fill up empty slots in sample.
-		sample = p.evict.fillSample(sample)
-
-		// Find minimally used item in sample.
-		minKey, minHits, minId, minCost := uint64(0), int64(math.MaxInt64), 0, int64(0)
-		for i, pair := range sample {
-			// Look up hit count for sample key.
-			if hits := p.admit.Estimate(pair.key); hits < minHits {
-				minKey, minHits, minId, minCost = pair.key, hits, i, pair.cost
-			}
+	for {
+		p.evictMu.Lock()
+		// No need to go any further if the item is already in the cache.
+		if has := p.evict.updateIfHas(key, cost); has {
+			p.evictMu.Unlock()
+			// An update does not count as an addition, so return false.
+			return victims, false
 		}
 
+		// If the execution reaches this point, the key doesn't exist in the cache.
+		// Calculate the remaining room in the cache (usually bytes).
+		room := p.evict.roomLeft(cost)
+		if room >= 0 {
+			// There's enough room in the cache to store the new item without
+			// overflowing. Do that now and stop here.
+			p.evict.add(key, cost)
+			p.metrics.add(costAdd, key, uint64(cost))
+			p.evictMu.Unlock()
+			return victims, true
+		}
+
+		if victims == nil {
+			victims = make([]*Item[V], 0)
+		}
+
+		// sample is the eviction candidate pool to be filled via random sampling.
+		// TODO: perhaps we should use a min heap here. Right now our time
+		// complexity is N for finding the min. Min heap should bring it down to
+		// O(lg N).
+
+		// Fill up empty slots in sample.
+		sample := p.evict.fillSample(make([]*policyPair, 0, lfuSample))
+		p.evictMu.Unlock()
+
+		if !hasIncHits {
+			incHits = p.estimate(key)
+			hasIncHits = true
+		}
+
+		// Find minimally used item in sample.
+		minPair, minHits, ok := p.minSample(sample)
+
 		// If the incoming item isn't worth keeping in the policy, reject.
-		if incHits < minHits {
+		if !ok || incHits < minHits {
 			p.metrics.add(rejectSets, key, 1)
 			return victims, false
 		}
 
 		// Delete the victim from metadata.
-		p.evict.del(minKey)
+		p.evictMu.Lock()
+		minCost, evicted := p.evict.del(minPair.key)
+		p.evictMu.Unlock()
+		if evicted {
+			// Store victim in evicted victims slice.
+			victims = append(victims, &Item[V]{
+				Key:      minPair.key,
+				Conflict: 0,
+				Cost:     minCost,
+			})
+		}
+	}
+}
 
-		// Delete the victim from sample.
-		sample[minId] = sample[len(sample)-1]
-		sample = sample[:len(sample)-1]
-		// Store victim in evicted victims slice.
-		victims = append(victims, &Item[V]{
-			Key:      minKey,
-			Conflict: 0,
-			Cost:     minCost,
-		})
+func (p *defaultPolicy[V]) estimate(key uint64) int64 {
+	p.admitMu.Lock()
+	hits := p.admit.Estimate(key)
+	p.admitMu.Unlock()
+	return hits
+}
+
+func (p *defaultPolicy[V]) minSample(sample []*policyPair) (*policyPair, int64, bool) {
+	if len(sample) == 0 {
+		return nil, 0, false
 	}
 
-	p.evict.add(key, cost)
-	p.metrics.add(costAdd, key, uint64(cost))
-	return victims, true
+	p.admitMu.Lock()
+	var minPair *policyPair
+	minHits := int64(math.MaxInt64)
+	for _, pair := range sample {
+		if hits := p.admit.Estimate(pair.key); hits < minHits {
+			minPair, minHits = pair, hits
+		}
+	}
+	p.admitMu.Unlock()
+	return minPair, minHits, true
 }
 
 func (p *defaultPolicy[V]) Has(key uint64) bool {
-	p.Lock()
+	p.evictMu.RLock()
 	_, exists := p.evict.keyCosts[key]
-	p.Unlock()
+	p.evictMu.RUnlock()
 	return exists
 }
 
 func (p *defaultPolicy[V]) Del(key uint64) {
-	p.Lock()
+	p.evictMu.Lock()
 	p.evict.del(key)
-	p.Unlock()
+	p.evictMu.Unlock()
 }
 
 func (p *defaultPolicy[V]) Cap() int64 {
-	p.Lock()
+	p.evictMu.RLock()
 	capacity := p.evict.getMaxCost() - p.evict.used
-	p.Unlock()
+	p.evictMu.RUnlock()
 	return capacity
 }
 
 func (p *defaultPolicy[V]) Update(key uint64, cost int64) {
-	p.Lock()
+	p.evictMu.Lock()
 	p.evict.updateIfHas(key, cost)
-	p.Unlock()
+	p.evictMu.Unlock()
 }
 
 func (p *defaultPolicy[V]) Cost(key uint64) int64 {
-	p.Lock()
+	p.evictMu.RLock()
 	if cost, found := p.evict.keyCosts[key]; found {
-		p.Unlock()
+		p.evictMu.RUnlock()
 		return cost
 	}
-	p.Unlock()
+	p.evictMu.RUnlock()
 	return -1
 }
 
 func (p *defaultPolicy[V]) Clear() {
-	p.Lock()
+	p.admitMu.Lock()
+	p.evictMu.Lock()
 	p.admit.clear()
 	p.evict.clear()
-	p.Unlock()
+	p.evictMu.Unlock()
+	p.admitMu.Unlock()
 }
 
 func (p *defaultPolicy[V]) Close() {
@@ -290,15 +313,16 @@ func (p *sampledLFU) fillSample(in []*policyPair) []*policyPair {
 	return in
 }
 
-func (p *sampledLFU) del(key uint64) {
+func (p *sampledLFU) del(key uint64) (int64, bool) {
 	cost, ok := p.keyCosts[key]
 	if !ok {
-		return
+		return 0, false
 	}
 	p.used -= cost
 	delete(p.keyCosts, key)
 	p.metrics.add(costEvict, key, uint64(cost))
 	p.metrics.add(keyEvict, key, 1)
+	return cost, true
 }
 
 func (p *sampledLFU) add(key uint64, cost int64) {

--- a/policy_test.go
+++ b/policy_test.go
@@ -6,6 +6,8 @@
 package ristretto
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -30,18 +32,110 @@ func TestPolicyProcessItems(t *testing.T) {
 	p := newDefaultPolicy[int](100, 10)
 	p.itemsCh <- []uint64{1, 2, 2}
 	time.Sleep(wait)
-	p.Lock()
+	p.admitMu.Lock()
 	require.Equal(t, int64(2), p.admit.Estimate(2))
 	require.Equal(t, int64(1), p.admit.Estimate(1))
-	p.Unlock()
+	p.admitMu.Unlock()
 
 	p.stop <- struct{}{}
 	<-p.done
 	p.itemsCh <- []uint64{3, 3, 3}
 	time.Sleep(wait)
-	p.Lock()
+	p.admitMu.Lock()
 	require.Equal(t, int64(0), p.admit.Estimate(3))
-	p.Unlock()
+	p.admitMu.Unlock()
+}
+
+func TestPolicyProcessItemsDoesNotWaitForEvictionLock(t *testing.T) {
+	p := newDefaultPolicy[int](100, 10)
+	defer p.Close()
+
+	p.evictMu.Lock()
+	defer p.evictMu.Unlock()
+
+	p.itemsCh <- []uint64{9}
+	require.Eventually(t, func() bool {
+		p.admitMu.Lock()
+		defer p.admitMu.Unlock()
+		return p.admit.Estimate(9) == 1
+	}, time.Second, time.Millisecond)
+}
+
+func waitForEvictionLockAvailable[V any](p *defaultPolicy[V], timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if p.evictMu.TryLock() {
+			p.evictMu.Unlock()
+			return true
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return false
+}
+
+type policyAddResult[V any] struct {
+	victims []*Item[V]
+	added   bool
+}
+
+func waitForPolicyAdd[V any](t *testing.T, done <-chan policyAddResult[V]) policyAddResult[V] {
+	t.Helper()
+	select {
+	case result := <-done:
+		return result
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Add")
+		return policyAddResult[V]{}
+	}
+}
+
+func TestPolicyAddDoesNotHoldEvictionLockWhileEstimating(t *testing.T) {
+	p := newDefaultPolicy[int](100, 10)
+	defer p.Close()
+	p.Add(1, 10)
+
+	p.admitMu.Lock()
+	addDone := make(chan policyAddResult[int], 1)
+	go func() {
+		victims, added := p.Add(2, 1)
+		addDone <- policyAddResult[int]{victims: victims, added: added}
+	}()
+
+	releasedEvict := waitForEvictionLockAvailable(p, time.Second)
+	p.admitMu.Unlock()
+	result := waitForPolicyAdd(t, addDone)
+
+	require.True(t, releasedEvict, "Add held evictMu while waiting on admission estimates")
+	require.True(t, result.added)
+	require.Len(t, result.victims, 1)
+	require.True(t, p.Has(2))
+}
+
+func TestPolicyAddRetriesWhenSampleVictimDisappears(t *testing.T) {
+	p := newDefaultPolicy[int](100, 10)
+	defer p.Close()
+	p.Add(1, 10)
+
+	p.admitMu.Lock()
+	addDone := make(chan policyAddResult[int], 1)
+	go func() {
+		victims, added := p.Add(2, 1)
+		addDone <- policyAddResult[int]{victims: victims, added: added}
+	}()
+
+	releasedEvict := waitForEvictionLockAvailable(p, time.Second)
+	if releasedEvict {
+		p.Del(1)
+	}
+	p.admitMu.Unlock()
+	result := waitForPolicyAdd(t, addDone)
+
+	require.True(t, releasedEvict, "Add held evictMu while waiting on admission estimates")
+	require.True(t, result.added)
+	require.Empty(t, result.victims)
+	require.False(t, p.Has(1))
+	require.True(t, p.Has(2))
+	require.Equal(t, int64(9), p.Cap())
 }
 
 func TestPolicyPush(t *testing.T) {
@@ -62,12 +156,14 @@ func TestPolicyAdd(t *testing.T) {
 	if victims, added := p.Add(1, 101); victims != nil || added {
 		t.Fatal("can't add an item bigger than entire cache")
 	}
-	p.Lock()
+	p.evictMu.Lock()
 	p.evict.add(1, 1)
+	p.evictMu.Unlock()
+	p.admitMu.Lock()
 	p.admit.Increment(1)
 	p.admit.Increment(2)
 	p.admit.Increment(3)
-	p.Unlock()
+	p.admitMu.Unlock()
 
 	victims, added := p.Add(1, 1)
 	require.Nil(t, victims)
@@ -112,9 +208,9 @@ func TestPolicyUpdate(t *testing.T) {
 	p := newDefaultPolicy[int](100, 10)
 	p.Add(1, 1)
 	p.Update(1, 2)
-	p.Lock()
+	p.evictMu.RLock()
 	require.Equal(t, int64(2), p.evict.keyCosts[1])
-	p.Unlock()
+	p.evictMu.RUnlock()
 }
 
 func TestPolicyCost(t *testing.T) {
@@ -134,6 +230,44 @@ func TestPolicyClear(t *testing.T) {
 	require.False(t, p.Has(1))
 	require.False(t, p.Has(2))
 	require.False(t, p.Has(3))
+}
+
+func TestPolicyConcurrentOperations(t *testing.T) {
+	p := newDefaultPolicy[int](1<<12, 256)
+	defer p.Close()
+	for i := 0; i < 256; i++ {
+		p.Add(uint64(i), 1)
+	}
+
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(seed uint64) {
+			defer wg.Done()
+			for i := uint64(0); i < 1000; i++ {
+				key := seed*1000 + i
+				switch i & 7 {
+				case 0:
+					p.Push([]uint64{key, key + 1, key + 2})
+				case 1:
+					p.Add(key, 1)
+				case 2:
+					_ = p.Has(key & 255)
+				case 3:
+					_ = p.Cost(key & 255)
+				case 4:
+					_ = p.Cap()
+				case 5:
+					p.Update(key&255, 1)
+				case 6:
+					p.Del(key & 255)
+				default:
+					p.Clear()
+				}
+			}
+		}(uint64(g))
+	}
+	wg.Wait()
 }
 
 func TestPolicyClose(t *testing.T) {
@@ -307,5 +441,139 @@ func BenchmarkSampledLFUFillSample(b *testing.B) {
 				e.fillSample(make([]*policyPair, 0, lfuSample))
 			}
 		})
+	}
+}
+
+func BenchmarkPolicyConcurrentHas(b *testing.B) {
+	b.ReportAllocs()
+	p := newDefaultPolicy[int](1<<20, 1<<20)
+	defer p.Close()
+	for i := 0; i < 4096; i++ {
+		p.Add(uint64(i), 1)
+	}
+
+	var workerID atomic.Uint64
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		key := workerID.Add(1) * 2654435761
+		for pb.Next() {
+			_ = p.Has(key & 4095)
+			key++
+		}
+	})
+}
+
+func BenchmarkPolicyConcurrentCost(b *testing.B) {
+	b.ReportAllocs()
+	p := newDefaultPolicy[int](1<<20, 1<<20)
+	defer p.Close()
+	for i := 0; i < 4096; i++ {
+		p.Add(uint64(i), 1)
+	}
+
+	var workerID atomic.Uint64
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		key := workerID.Add(1) * 2654435761
+		for pb.Next() {
+			_ = p.Cost(key & 4095)
+			key++
+		}
+	})
+}
+
+func BenchmarkPolicyConcurrentCap(b *testing.B) {
+	b.ReportAllocs()
+	p := newDefaultPolicy[int](1<<20, 1<<20)
+	defer p.Close()
+	for i := 0; i < 4096; i++ {
+		p.Add(uint64(i), 1)
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = p.Cap()
+		}
+	})
+}
+
+func BenchmarkPolicyAddWithEviction(b *testing.B) {
+	b.ReportAllocs()
+	p := newDefaultPolicy[int](1<<20, 1024)
+	defer p.Close()
+	for i := 0; i < 1024; i++ {
+		p.Add(uint64(i), 1)
+	}
+
+	key := uint64(1024)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.Add(key, 1)
+		key++
+	}
+}
+
+func processPolicyFrequencyBatches(b *testing.B, p *defaultPolicy[int], batch []uint64) {
+	for i := 0; i < b.N; i++ {
+		p.itemsCh <- batch
+	}
+}
+
+func reportPolicyFrequencyThroughput(b *testing.B, batchSize int) {
+	elapsed := b.Elapsed().Seconds()
+	if elapsed > 0 {
+		b.ReportMetric(float64(b.N*batchSize)/elapsed, "frequency-keys/s")
+	}
+}
+
+func BenchmarkPolicyProcessItems(b *testing.B) {
+	p := newDefaultPolicy[int](1<<20, 1024)
+	defer p.Close()
+	batch := []uint64{1, 2, 3, 4}
+
+	b.SetBytes(int64(len(batch) * 8))
+	b.ResetTimer()
+	processPolicyFrequencyBatches(b, p, batch)
+	b.StopTimer()
+	reportPolicyFrequencyThroughput(b, len(batch))
+}
+
+func BenchmarkPolicyProcessItemsDuringEviction(b *testing.B) {
+	p := newDefaultPolicy[int](1<<20, 1024)
+	defer p.Close()
+	for i := 0; i < 1024; i++ {
+		p.Add(uint64(i), 1)
+	}
+
+	var stop atomic.Bool
+	var adds atomic.Uint64
+	start := make(chan struct{})
+	addDone := make(chan struct{})
+	go func() {
+		defer close(addDone)
+		<-start
+		key := uint64(1024)
+		for !stop.Load() {
+			p.Add(key, 1)
+			adds.Add(1)
+			key++
+		}
+	}()
+
+	batch := []uint64{1, 2, 3, 4}
+	b.SetBytes(int64(len(batch) * 8))
+	b.ResetTimer()
+	close(start)
+	processPolicyFrequencyBatches(b, p, batch)
+	b.StopTimer()
+
+	stop.Store(true)
+	<-addDone
+
+	reportPolicyFrequencyThroughput(b, len(batch))
+	elapsed := b.Elapsed().Seconds()
+	if elapsed > 0 {
+		b.ReportMetric(float64(adds.Load())/elapsed, "add-calls/s")
 	}
 }


### PR DESCRIPTION
## Summary

Split the policy lock into independent admission and eviction locks. This prevents eviction work in `Add` from blocking TinyLFU frequency updates in `processItems` and allows eviction metadata reads to run concurrently.

## Changes

- Protect TinyLFU with `admitMu` and sampledLFU with `evictMu`.
- Release the eviction lock before frequency estimation and validate sampled victims before deletion.
- Add concurrency tests and focused policy benchmarks.

## Benchmark

CPU: Apple M5 (darwin / arm64)

| Name | Before | After | Change |
|---|---:|---:|---:|
| ProcessItems | 301.1 ns/op | 311.4 ns/op | +3.4% |
| ProcessItemsDuringEviction | 47,031 ns/op | 431.5 ns/op | -99.1% |
| Frequency throughput during eviction | 85,050 keys/s | 9,270,112 keys/s | 109x |
| Concurrent Has | 164.6 ns/op | 122.9 ns/op | -25.3% |
| Concurrent Cost | 145.2 ns/op | 103.4 ns/op | -28.8% |
| Concurrent Cap | 102.1 ns/op | 77.43 ns/op | -24.2% |
| Add with eviction | 908.1 ns/op | 1,079 ns/op | +18.8% |

## Checklist
- [x] Code compiles correctly and linting passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable