### PR TITLE
fix: handle mremap size mismatch on Linux s390x

### DIFF
--- a/z/mremap_nosize.go
+++ b/z/mremap_nosize.go
@@ -1,5 +1,5 @@
-//go:build (arm64 || arm) && linux && !js
-// +build arm64 arm
+//go:build (arm64 || arm || s390x) && linux && !js
+// +build arm64 arm s390x
 // +build linux
 // +build !js
 

--- a/z/mremap_size.go
+++ b/z/mremap_size.go
@@ -1,5 +1,5 @@
-//go:build linux && !arm64 && !arm && !js
-// +build linux,!arm64,!arm,!js
+//go:build linux && !arm64 && !arm && !s390x && !js
+// +build linux,!arm64,!arm,!s390x,!js
 
 /*
  * SPDX-FileCopyrightText: © 2017-2025 Istari Digital, Inc.


### PR DESCRIPTION
### **Description**

This PR fixes a runtime crash on IBM s390x caused by a missing build tag
that routes s390x to the wrong `mremap` implementation.

### **Problem**

On Linux s390x, the kernel does not support shrinking a memory mapping via
`mremap(2)` — it returns the original allocation size instead of the
requested smaller size.

BadgerDB uses Ristretto for memory-mapped file operations. On restart, when
a stale memtable file exists from a previous unclean shutdown, Ristretto
calls `mremap` to shrink the mapping from its pre-allocated size (128 MB)
down to the actual data size. On s390x the kernel ignores the shrink and
returns 134,217,728 (128 MB). `mremap_size.go` then asserts
`returned == requested` and returns a fatal error, crashing the application:

mremap size mismatch: requested: 2628 got: 134217728

ARM64 has identical kernel behavior and was already fixed via
`mremap_nosize.go`. s390x was simply never added to that file's build tags.

### **Fix**

Add `s390x` to the build tags of `mremap_nosize.go` (safe path — skips
size assertion) and exclude it from `mremap_size.go` (broken path —
asserts size). This is the identical pattern already in place for ARM64.

### **Validation Performed**

The fix was validated by building and testing on multiple architectures:

- s390x (IBM Fyre VM, RHEL on IBM Z) - Native full runtime test
  - Application restarts cleanly after unclean shutdown with stale .mem present
  - No mremap size mismatch error after fix applied

- linux/arm64 and linux/amd64 (macOS ARM64 cross-compile) - go build ./... - Build successful on both

- x86_64 (Ubuntu Linux VM, native) - go build ./... - Build successful

### Impact

Resolves crash for all BadgerDB/Ristretto users on Linux s390x(IBM)
Build-tag change only — zero runtime impact on other architectures
No functional logic changes introduced
 
**Checklist**

- [x] The PR title follows the Conventional Commits syntax, leading with `fix:`
- [x] Code compiles correctly on s390x, x86_64, linux/arm64, linux/amd64

Note: A unit test for this fix is not feasible — the mremap shrink behavior
is specific to the Linux s390x kernel and cannot be reproduced or mocked on
other architectures. Runtime validation was performed directly on an IBM Z
(s390x) RHEL VM as described in the Validation section above.