### PR TITLE
fix: revert eager sampledLFU keyCosts pre-allocation (#482)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ adhere to [Semantic Versioning](http://semver.org/spec/v2.0.0.html) starting v1.
 
 ## [Unreleased]
 
+## [v2.4.2] - 2026-07-07
+
+### Fixed
+
+- Revert eager pre-allocation of the `sampledLFU` `keyCosts` map (#482), which
+  allocated `NumCounters/10` map buckets at boot and caused a large RSS
+  regression for caches with high `NumCounters`
+
+**Full Changelog**: https://github.com/dgraph-io/ristretto/compare/v2.4.1...v2.4.2
+
 ## [v2.4.1] - 2026-07-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ adhere to [Semantic Versioning](http://semver.org/spec/v2.0.0.html) starting v1.
 
 ### Fixed
 
-- Revert eager pre-allocation of the `sampledLFU` `keyCosts` map (#482), which
-  allocated `NumCounters/10` map buckets at boot and caused a large RSS
-  regression for caches with high `NumCounters`
+- Revert eager pre-allocation of the `sampledLFU` `keyCosts` map (#482), which allocated
+  `NumCounters/10` map buckets at boot and caused a large RSS regression for caches with high
+  `NumCounters`
 
 **Full Changelog**: https://github.com/dgraph-io/ristretto/compare/v2.4.1...v2.4.2
 

--- a/policy.go
+++ b/policy.go
@@ -37,7 +37,7 @@ type defaultPolicy[V any] struct {
 func newDefaultPolicy[V any](numCounters, maxCost int64) *defaultPolicy[V] {
 	p := &defaultPolicy[V]{
 		admit:   newTinyLFU(numCounters),
-		evict:   newSampledLFU(maxCost, numCounters),
+		evict:   newSampledLFU(maxCost),
 		itemsCh: make(chan []uint64, 3),
 		stop:    make(chan struct{}),
 		done:    make(chan struct{}),
@@ -249,19 +249,14 @@ type sampledLFU struct {
 	// or slice can be relied upon to be 64-bit aligned."
 	maxCost  int64
 	used     int64
-	keyCap   int64
 	metrics  *Metrics
 	keyCosts map[uint64]int64
 }
 
-func newSampledLFU(maxCost, numCounters int64) *sampledLFU {
-	// Pre-allocate keyCosts assuming the recommended 10:1 counter-to-item ratio
-	// to minimize map resizing.
-	capacity := numCounters / 10
+func newSampledLFU(maxCost int64) *sampledLFU {
 	return &sampledLFU{
-		keyCosts: make(map[uint64]int64, capacity),
+		keyCosts: make(map[uint64]int64),
 		maxCost:  maxCost,
-		keyCap:   capacity,
 	}
 }
 
@@ -327,7 +322,7 @@ func (p *sampledLFU) updateIfHas(key uint64, cost int64) bool {
 
 func (p *sampledLFU) clear() {
 	p.used = 0
-	p.keyCosts = make(map[uint64]int64, p.keyCap)
+	p.keyCosts = make(map[uint64]int64)
 }
 
 // tinyLFU is an admission helper that keeps track of access frequency using

--- a/policy_test.go
+++ b/policy_test.go
@@ -160,7 +160,7 @@ func TestAddAfterClose(t *testing.T) {
 }
 
 func TestSampledLFUAdd(t *testing.T) {
-	e := newSampledLFU(4, 100)
+	e := newSampledLFU(4)
 	e.add(1, 1)
 	e.add(2, 2)
 	e.add(3, 1)
@@ -169,7 +169,7 @@ func TestSampledLFUAdd(t *testing.T) {
 }
 
 func TestSampledLFUDel(t *testing.T) {
-	e := newSampledLFU(4, 100)
+	e := newSampledLFU(4)
 	e.add(1, 1)
 	e.add(2, 2)
 	e.del(2)
@@ -180,7 +180,7 @@ func TestSampledLFUDel(t *testing.T) {
 }
 
 func TestSampledLFUUpdate(t *testing.T) {
-	e := newSampledLFU(4, 100)
+	e := newSampledLFU(4)
 	e.add(1, 1)
 	require.True(t, e.updateIfHas(1, 2))
 	require.Equal(t, int64(2), e.used)
@@ -188,7 +188,7 @@ func TestSampledLFUUpdate(t *testing.T) {
 }
 
 func TestSampledLFUClear(t *testing.T) {
-	e := newSampledLFU(4, 100)
+	e := newSampledLFU(4)
 	e.add(1, 1)
 	e.add(2, 2)
 	e.add(3, 1)
@@ -198,7 +198,7 @@ func TestSampledLFUClear(t *testing.T) {
 }
 
 func TestSampledLFURoom(t *testing.T) {
-	e := newSampledLFU(16, 1000)
+	e := newSampledLFU(16)
 	e.add(1, 1)
 	e.add(2, 2)
 	e.add(3, 3)
@@ -206,7 +206,7 @@ func TestSampledLFURoom(t *testing.T) {
 }
 
 func TestSampledLFUSample(t *testing.T) {
-	e := newSampledLFU(16, 1000)
+	e := newSampledLFU(16)
 	e.add(4, 4)
 	e.add(5, 5)
 	sample := e.fillSample([]*policyPair{
@@ -262,50 +262,4 @@ func TestTinyLFUClear(t *testing.T) {
 	a.clear()
 	require.Equal(t, int64(0), a.incrs)
 	require.Equal(t, int64(0), a.Estimate(3))
-}
-
-func BenchmarkSampledLFUPopulate(b *testing.B) {
-	sizes := []struct {
-		name string
-		n    int
-	}{
-		{"1K", 1000},
-		{"10K", 10000},
-		{"100K", 100000},
-		{"1M", 1000000},
-	}
-	for _, s := range sizes {
-		b.Run(s.name, func(b *testing.B) {
-			for n := 0; n < b.N; n++ {
-				e := newSampledLFU(int64(s.n*100), int64(s.n*10))
-				for i := 0; i < s.n; i++ {
-					e.add(uint64(i), 1)
-				}
-			}
-		})
-	}
-}
-
-func BenchmarkSampledLFUFillSample(b *testing.B) {
-	sizes := []struct {
-		name string
-		n    int
-	}{
-		{"100", 100},
-		{"1K", 1000},
-		{"10K", 10000},
-		{"100K", 100000},
-	}
-	for _, s := range sizes {
-		b.Run(s.name, func(b *testing.B) {
-			e := newSampledLFU(int64(s.n*100), int64(s.n*10))
-			for i := 0; i < s.n; i++ {
-				e.add(uint64(i), 1)
-			}
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				e.fillSample(make([]*policyPair, 0, lfuSample))
-			}
-		})
-	}
 }


### PR DESCRIPTION
## Summary

Reverts the eager `sampledLFU` `keyCosts` pre-allocation from #482, which introduced a boot-time RSS regression in `v2.4.1`.

## Why

#482 pre-sized `keyCosts` to `NumCounters/10` in `newSampledLFU` and made `clear()` re-inflate to the same capacity. For caches with a large `NumCounters`, that commits hundreds of MB of empty map buckets at construction — regardless of `MaxCost` or the actual working set — and `clear()` stops releasing the map. A Dgraph build on `v2.4.1` showed ~575 MB of flat, boot-time RSS attributable to this map alone, with `NumCounters` unchanged. Full analysis in #493.

The pre-allocation was also keyed off the wrong quantity: `keyCosts` tracks admitted items, which are bounded by `MaxCost` and the cost distribution, not by the counter count.

## Changes

- Revert `newSampledLFU` to `make(map[uint64]int64)` (lazy growth) and drop the `numCounters` parameter and `keyCap` field.
- Revert `clear()` to `make(map[uint64]int64)` so a reset actually frees the map.
- Revert the accompanying `policy_test.go` changes from #482.

## Testing

- `go test .` passes locally.

Eager sizing may still be worth offering as an opt-in `Config` hint rather than a fixed `NumCounters/10` default; tracking that in #493.

Fixes #493
